### PR TITLE
fix: Resolve Windows build permission issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ go.work.sum
 bin/
 dist/
 build/
+.cache/
 
 # Environment variables
 .env

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,17 @@ BINARY=bin/$(APP_NAME)
 MAIN_PATH=cmd/$(APP_NAME)/main.go
 DOCKER_COMPOSE=docker-compose
 
+# Go build cache directories (Windows-friendly, keeps everything in project)
+PROJECT_DIR=$(shell pwd)
+CACHE_DIR=$(PROJECT_DIR)/.cache
+GO_BUILD_CACHE=$(CACHE_DIR)/go-build
+GO_MOD_CACHE=$(CACHE_DIR)/go-mod
+
+# Export Go environment variables to use project directory
+export GOCACHE=$(GO_BUILD_CACHE)
+export GOMODCACHE=$(GO_MOD_CACHE)
+export GOTMPDIR=$(CACHE_DIR)/tmp
+
 # Default target
 help: ## Show this help message
 	@echo "ActaLog - Makefile Commands"
@@ -14,7 +25,7 @@ help: ## Show this help message
 
 build: ## Build the application binary
 	@echo "Building $(APP_NAME)..."
-	@mkdir -p bin
+	@mkdir -p bin $(GO_BUILD_CACHE) $(GO_MOD_CACHE) $(CACHE_DIR)/tmp
 	@go build -o $(BINARY) $(MAIN_PATH)
 	@echo "Build complete: $(BINARY)"
 
@@ -65,6 +76,7 @@ fmt: ## Format code
 clean: ## Clean build artifacts
 	@echo "Cleaning build artifacts..."
 	@rm -rf bin/
+	@rm -rf .cache/
 	@rm -f coverage.out coverage.html
 	@rm -f *.db *.sqlite *.sqlite3
 	@echo "Clean complete"

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,88 @@
+@echo off
+REM ActaLog Build Script for Windows
+REM This script provides an alternative to Makefile for Windows users
+
+setlocal
+
+REM Set project-local cache directories to avoid Windows permission issues
+set PROJECT_DIR=%~dp0
+set CACHE_DIR=%PROJECT_DIR%.cache
+set GOCACHE=%CACHE_DIR%\go-build
+set GOMODCACHE=%CACHE_DIR%\go-mod
+set GOTMPDIR=%CACHE_DIR%\tmp
+
+REM Create directories if they don't exist
+if not exist bin mkdir bin
+if not exist %CACHE_DIR% mkdir %CACHE_DIR%
+if not exist %GOCACHE% mkdir %GOCACHE%
+if not exist %GOMODCACHE% mkdir %GOMODCACHE%
+if not exist %GOTMPDIR% mkdir %GOTMPDIR%
+
+if "%1"=="" goto help
+if "%1"=="build" goto build
+if "%1"=="run" goto run
+if "%1"=="test" goto test
+if "%1"=="clean" goto clean
+if "%1"=="fmt" goto fmt
+if "%1"=="help" goto help
+goto help
+
+:build
+echo Building ActaLog...
+go build -o bin\actalog.exe cmd\actalog\main.go
+if %errorlevel% equ 0 (
+    echo Build complete: bin\actalog.exe
+) else (
+    echo Build failed!
+    exit /b 1
+)
+goto end
+
+:run
+echo Running ActaLog...
+go run cmd\actalog\main.go
+goto end
+
+:test
+echo Running tests...
+go test -v -race -coverprofile=coverage.out ./...
+if %errorlevel% equ 0 (
+    go tool cover -html=coverage.out -o coverage.html
+    echo Coverage report generated: coverage.html
+)
+goto end
+
+:clean
+echo Cleaning build artifacts...
+if exist bin rmdir /s /q bin
+if exist .cache rmdir /s /q .cache
+if exist coverage.out del coverage.out
+if exist coverage.html del coverage.html
+if exist *.db del *.db
+if exist *.sqlite del *.sqlite
+if exist *.sqlite3 del *.sqlite3
+echo Clean complete
+goto end
+
+:fmt
+echo Formatting code...
+go fmt ./...
+goto end
+
+:help
+echo ActaLog - Windows Build Script
+echo.
+echo Usage: build.bat [command]
+echo.
+echo Available commands:
+echo   build      Build the application
+echo   run        Run the application
+echo   test       Run tests with coverage
+echo   clean      Clean build artifacts
+echo   fmt        Format Go code
+echo   help       Show this help message
+echo.
+goto end
+
+:end
+endlocal

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -53,6 +53,62 @@ npm run dev
 
 Frontend will be available at http://localhost:3000
 
+## Windows Users
+
+### Option 1: Use the Build Script (Recommended)
+
+Windows users can use the provided `build.bat` script instead of Make:
+
+```cmd
+# Build the application
+build.bat build
+
+# Run the application
+build.bat run
+
+# Run tests
+build.bat test
+
+# Format code
+build.bat fmt
+
+# Clean build artifacts
+build.bat clean
+
+# Show help
+build.bat help
+```
+
+### Option 2: Use Make with Git Bash or WSL
+
+If you have Git Bash or WSL installed, you can use the Makefile commands as shown in the backend setup.
+
+### Common Windows Issue: Access Denied
+
+If you encounter an error like:
+```
+go: creating work dir: mkdir C:\WINDOWS\go-build...: Access is denied.
+```
+
+This is because Go tries to create its build cache in the Windows system directory. The Makefile and build.bat script automatically fix this by using the project's `.cache/` directory instead.
+
+If using `go` commands directly, set these environment variables first:
+
+```cmd
+set GOCACHE=%CD%\.cache\go-build
+set GOMODCACHE=%CD%\.cache\go-mod
+set GOTMPDIR=%CD%\.cache\tmp
+go build -o bin\actalog.exe cmd\actalog\main.go
+```
+
+Or in PowerShell:
+```powershell
+$env:GOCACHE="$PWD\.cache\go-build"
+$env:GOMODCACHE="$PWD\.cache\go-mod"
+$env:GOTMPDIR="$PWD\.cache\tmp"
+go build -o bin\actalog.exe cmd\actalog\main.go
+```
+
 ## Docker Setup (Alternative)
 
 ```bash


### PR DESCRIPTION
Fix "Access is denied" error when building on Windows by configuring Go to use project-local cache directories instead of system directories.

Changes:
- Update Makefile to set GOCACHE, GOMODCACHE, and GOTMPDIR to .cache/
- Create cache directories automatically during build
- Add .cache/ to .gitignore
- Add build.bat script for Windows users without Make
- Update SETUP.md with Windows-specific instructions

This keeps all build artifacts within the project directory, avoiding Windows permission issues when Go tries to write to C:\WINDOWS\.

Windows users can now use:
- build.bat build (recommended)
- make build (with Git Bash/WSL)
- Direct go commands with environment variables set

Fixes build errors on Windows while maintaining Linux/Mac compatibility.