### PR TITLE
fix: Remove non-existent esbuild version override

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -34,8 +34,5 @@
     "vite-plugin-vuetify": "^2.0.0",
     "sass": "^1.80.0",
     "globals": "^15.12.0"
-  },
-  "overrides": {
-    "esbuild": "^0.24.3"
   }
 }


### PR DESCRIPTION
Remove esbuild ^0.24.3 override as this version doesn't exist yet. Vite 6.0.5 will use its default bundled esbuild version which is safe.

This fixes npm install error:
  No matching version found for esbuild@^0.24.3

The esbuild security fix will come automatically when the new version is released and Vite updates its dependency.