### PR TITLE
docs: Add MySQL/MariaDB configuration example to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,15 @@ DB_SSLMODE=disable
 # DB_NAME=actalog
 # DB_SSLMODE=require
 
+# For MySQL/MariaDB in production:
+# DB_DRIVER=mysql
+# DB_HOST=localhost
+# DB_PORT=3306
+# DB_USER=actalog
+# DB_PASSWORD=your_secure_password
+# DB_NAME=actalog
+# DB_SSLMODE is not used with MySQL
+
 # JWT Configuration
 # IMPORTANT: Generate a strong secret for production!
 # You can use: openssl rand -base64 32


### PR DESCRIPTION
Add commented-out MySQL/MariaDB configuration example to match the existing PostgreSQL example. This ensures users have a complete reference for all supported database configurations in the environment template file.