### PR TITLE
feat(auth): Add password reset frontend components (Part 3/3)

### DIFF
--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -21,6 +21,18 @@ const router = createRouter({
       meta: { requiresAuth: false }
     },
     {
+      path: '/forgot-password',
+      name: 'forgot-password',
+      component: () => import('@/views/ForgotPasswordView.vue'),
+      meta: { requiresAuth: false }
+    },
+    {
+      path: '/reset-password/:token',
+      name: 'reset-password',
+      component: () => import('@/views/ResetPasswordView.vue'),
+      meta: { requiresAuth: false }
+    },
+    {
       path: '/dashboard',
       name: 'dashboard',
       component: () => import('@/views/DashboardView.vue'),
@@ -71,7 +83,8 @@ router.beforeEach((to, from, next) => {
 
   if (requiresAuth && !authStore.isAuthenticated) {
     next('/login')
-  } else if ((to.name === 'login' || to.name === 'register') && authStore.isAuthenticated) {
+  } else if ((to.name === 'login' || to.name === 'register' || to.name === 'forgot-password' || to.name === 'reset-password') && authStore.isAuthenticated) {
+    // If already authenticated, redirect password reset flows to dashboard
     next('/dashboard')
   } else {
     next()

--- a/web/src/views/ForgotPasswordView.vue
+++ b/web/src/views/ForgotPasswordView.vue
@@ -1,0 +1,106 @@
+<template>
+  <v-container class="fill-height" fluid>
+    <v-row align="center" justify="center">
+      <v-col cols="12" sm="8" md="4">
+        <v-card elevation="4" rounded="lg">
+          <v-card-title class="text-h4 text-center pa-6">
+            <div class="d-flex flex-column align-center">
+              <div class="text-primary mb-2">Reset Password</div>
+              <div class="text-body-2 text-medium-emphasis">
+                Enter your email to receive a reset link
+              </div>
+            </div>
+          </v-card-title>
+
+          <v-card-text class="pa-6">
+            <v-alert
+              v-if="successMessage"
+              type="success"
+              variant="tonal"
+              class="mb-4"
+            >
+              {{ successMessage }}
+            </v-alert>
+
+            <v-alert
+              v-if="errorMessage"
+              type="error"
+              variant="tonal"
+              class="mb-4"
+            >
+              {{ errorMessage }}
+            </v-alert>
+
+            <v-form @submit.prevent="handleSubmit" :disabled="submitted">
+              <v-text-field
+                v-model="email"
+                label="Email"
+                type="email"
+                prepend-inner-icon="mdi-email"
+                required
+                :error-messages="errors.email"
+                :disabled="submitted"
+              />
+
+              <v-btn
+                type="submit"
+                color="primary"
+                block
+                size="large"
+                class="mt-6"
+                :loading="loading"
+                :disabled="submitted"
+              >
+                Send Reset Link
+              </v-btn>
+
+              <div class="text-center mt-4">
+                <router-link to="/login" class="text-decoration-none">
+                  <v-icon size="small" class="mr-1">mdi-arrow-left</v-icon>
+                  Back to Sign In
+                </router-link>
+              </div>
+            </v-form>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import axios from 'axios'
+
+const email = ref('')
+const loading = ref(false)
+const submitted = ref(false)
+const errors = ref({})
+const successMessage = ref('')
+const errorMessage = ref('')
+
+const handleSubmit = async () => {
+  // Reset messages and errors
+  errors.value = {}
+  successMessage.value = ''
+  errorMessage.value = ''
+  loading.value = true
+
+  try {
+    const response = await axios.post('/api/auth/forgot-password', {
+      email: email.value
+    })
+
+    successMessage.value = response.data.message || 'If your email is registered, you will receive a password reset link shortly'
+    submitted.value = true
+  } catch (error) {
+    if (error.response?.data?.message) {
+      errorMessage.value = error.response.data.message
+    } else {
+      errorMessage.value = 'Failed to send reset link. Please try again.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -42,6 +42,12 @@
                 Sign In
               </v-btn>
 
+              <div class="text-center mt-3">
+                <router-link to="/forgot-password" class="text-decoration-none text-body-2">
+                  Forgot password?
+                </router-link>
+              </div>
+
               <div class="text-center mt-4">
                 <router-link to="/register" class="text-decoration-none">
                   Don't have an account? Sign up

--- a/web/src/views/ResetPasswordView.vue
+++ b/web/src/views/ResetPasswordView.vue
@@ -1,0 +1,155 @@
+<template>
+  <v-container class="fill-height" fluid>
+    <v-row align="center" justify="center">
+      <v-col cols="12" sm="8" md="4">
+        <v-card elevation="4" rounded="lg">
+          <v-card-title class="text-h4 text-center pa-6">
+            <div class="d-flex flex-column align-center">
+              <div class="text-primary mb-2">Set New Password</div>
+              <div class="text-body-2 text-medium-emphasis">
+                Enter your new password below
+              </div>
+            </div>
+          </v-card-title>
+
+          <v-card-text class="pa-6">
+            <v-alert
+              v-if="successMessage"
+              type="success"
+              variant="tonal"
+              class="mb-4"
+            >
+              {{ successMessage }}
+            </v-alert>
+
+            <v-alert
+              v-if="errorMessage"
+              type="error"
+              variant="tonal"
+              class="mb-4"
+            >
+              {{ errorMessage }}
+            </v-alert>
+
+            <v-form v-if="!resetSuccess" @submit.prevent="handleSubmit">
+              <v-text-field
+                v-model="newPassword"
+                label="New Password"
+                type="password"
+                prepend-inner-icon="mdi-lock"
+                required
+                :error-messages="errors.password"
+                hint="Minimum 8 characters"
+                persistent-hint
+              />
+
+              <v-text-field
+                v-model="confirmPassword"
+                label="Confirm Password"
+                type="password"
+                prepend-inner-icon="mdi-lock-check"
+                required
+                :error-messages="errors.confirmPassword"
+                class="mt-4"
+              />
+
+              <v-btn
+                type="submit"
+                color="primary"
+                block
+                size="large"
+                class="mt-6"
+                :loading="loading"
+              >
+                Reset Password
+              </v-btn>
+            </v-form>
+
+            <div v-if="resetSuccess" class="text-center">
+              <v-btn
+                to="/login"
+                color="primary"
+                size="large"
+                prepend-icon="mdi-login"
+              >
+                Go to Sign In
+              </v-btn>
+            </div>
+
+            <div v-if="!resetSuccess" class="text-center mt-4">
+              <router-link to="/login" class="text-decoration-none">
+                <v-icon size="small" class="mr-1">mdi-arrow-left</v-icon>
+                Back to Sign In
+              </router-link>
+            </div>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import axios from 'axios'
+
+const route = useRoute()
+
+const newPassword = ref('')
+const confirmPassword = ref('')
+const loading = ref(false)
+const resetSuccess = ref(false)
+const errors = ref({})
+const successMessage = ref('')
+const errorMessage = ref('')
+const token = ref('')
+
+onMounted(() => {
+  // Get token from URL parameter
+  token.value = route.params.token || ''
+
+  if (!token.value) {
+    errorMessage.value = 'Invalid reset link. Please request a new password reset.'
+  }
+})
+
+const handleSubmit = async () => {
+  // Reset messages and errors
+  errors.value = {}
+  successMessage.value = ''
+  errorMessage.value = ''
+
+  // Validate passwords match
+  if (newPassword.value !== confirmPassword.value) {
+    errors.value.confirmPassword = 'Passwords do not match'
+    return
+  }
+
+  // Validate password length
+  if (newPassword.value.length < 8) {
+    errors.value.password = 'Password must be at least 8 characters long'
+    return
+  }
+
+  loading.value = true
+
+  try {
+    const response = await axios.post('/api/auth/reset-password', {
+      token: token.value,
+      new_password: newPassword.value
+    })
+
+    successMessage.value = response.data.message || 'Password has been reset successfully. You can now sign in with your new password.'
+    resetSuccess.value = true
+  } catch (error) {
+    if (error.response?.data?.message) {
+      errorMessage.value = error.response.data.message
+    } else {
+      errorMessage.value = 'Failed to reset password. Please try again or request a new reset link.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+</script>


### PR DESCRIPTION
Complete the password reset feature with frontend Vue components:

Frontend Components:
- Create ForgotPasswordView.vue for password reset requests
  * Email input form with validation
  * POST to /api/auth/forgot-password
  * Success message with security-conscious wording
  * Disabled form after submission to prevent duplicates

- Create ResetPasswordView.vue for setting new password
  * Extract reset token from URL params
  * Password and confirm password fields with validation
  * Minimum 8 character requirement
  * POST to /api/auth/reset-password
  * Success state with redirect to login

Router Updates:
- Add /forgot-password route (no auth required)
- Add /reset-password/:token route (no auth required)
- Updated navigation guard to redirect authenticated users

LoginView Enhancement:
- Add "Forgot password?" link between sign-in button and register link
- Consistent styling with existing links

This completes the 3-part password reset implementation: Part 1: Database migration and domain models
Part 2: Backend services and API endpoints
Part 3: Frontend components and user flows