### PR TITLE
feat: Add Remember Me functionality (v0.3.2-beta)

### DIFF
--- a/cmd/actalog/main.go
+++ b/cmd/actalog/main.go
@@ -91,6 +91,7 @@ func main() {
 
 	// Initialize repositories
 	userRepo := repository.NewSQLiteUserRepository(db)
+	refreshTokenRepo := repository.NewSQLiteRefreshTokenRepository(db)
 	movementRepo := repository.NewSQLiteMovementRepository(db)
 	workoutRepo := repository.NewSQLiteWorkoutRepository(db)
 	workoutMovementRepo := repository.NewSQLiteWorkoutMovementRepository(db)
@@ -127,8 +128,10 @@ func main() {
 	// Initialize services
 	userService := service.NewUserService(
 		userRepo,
+		refreshTokenRepo,
 		cfg.JWT.SecretKey,
 		cfg.JWT.ExpirationTime,
+		cfg.JWT.RefreshTokenDuration,
 		cfg.App.AllowRegistration,
 		emailService,
 		appURL,
@@ -182,6 +185,8 @@ func main() {
 		r.Post("/auth/reset-password", authHandler.ResetPassword)
 		r.Get("/auth/verify-email", authHandler.VerifyEmail)
 		r.Post("/auth/resend-verification", authHandler.ResendVerification)
+		r.Post("/auth/refresh", authHandler.RefreshToken)
+		r.Post("/auth/revoke", authHandler.RevokeToken)
 
 		// Movement routes (public for browsing)
 		r.Get("/movements", movementHandler.ListStandard)

--- a/configs/config.go
+++ b/configs/config.go
@@ -40,9 +40,10 @@ type DatabaseConfig struct {
 
 // JWTConfig holds JWT authentication configuration
 type JWTConfig struct {
-	SecretKey      string
-	ExpirationTime time.Duration
-	Issuer         string
+	SecretKey            string
+	ExpirationTime       time.Duration
+	RefreshTokenDuration time.Duration
+	Issuer               string
 }
 
 // AppConfig holds application-specific configuration
@@ -94,9 +95,10 @@ func Load() (*Config, error) {
 			SSLMode:  getEnv("DB_SSLMODE", "disable"),
 		},
 		JWT: JWTConfig{
-			SecretKey:      getEnv("JWT_SECRET", ""), // Must be set in production
-			ExpirationTime: getEnvDuration("JWT_EXPIRATION", 24*time.Hour),
-			Issuer:         getEnv("JWT_ISSUER", "actalog"),
+			SecretKey:            getEnv("JWT_SECRET", ""), // Must be set in production
+			ExpirationTime:       getEnvDuration("JWT_EXPIRATION", 24*time.Hour),
+			RefreshTokenDuration: getEnvDuration("JWT_REFRESH_DURATION", 30*24*time.Hour), // 30 days
+			Issuer:               getEnv("JWT_ISSUER", "actalog"),
 		},
 		App: AppConfig{
 			Name:              "ActaLog",

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -7,6 +7,7 @@ import (
 
 // User represents a user in the system
 type User struct {
+<<<<<<< HEAD
 	ID                          int64      `json:"id" db:"id"`
 	Email                       string     `json:"email" db:"email"`
 	PasswordHash                string     `json:"-" db:"password_hash"` // Never serialize password
@@ -22,6 +23,30 @@ type User struct {
 	CreatedAt                   time.Time  `json:"created_at" db:"created_at"`
 	UpdatedAt                   time.Time  `json:"updated_at" db:"updated_at"`
 	LastLoginAt                 *time.Time `json:"last_login_at,omitempty" db:"last_login_at"`
+=======
+	ID                   int64      `json:"id" db:"id"`
+	Email                string     `json:"email" db:"email"`
+	PasswordHash         string     `json:"-" db:"password_hash"` // Never serialize password
+	Name                 string     `json:"name" db:"name"`
+	ProfileImage         *string    `json:"profile_image,omitempty" db:"profile_image"`
+	Role                 string     `json:"role" db:"role"` // user, admin
+	ResetToken           *string    `json:"-" db:"reset_token"` // Never serialize reset token
+	ResetTokenExpiresAt  *time.Time `json:"-" db:"reset_token_expires_at"`
+	CreatedAt            time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt            time.Time  `json:"updated_at" db:"updated_at"`
+	LastLoginAt          *time.Time `json:"last_login_at,omitempty" db:"last_login_at"`
+>>>>>>> 6401243 (feat: Add Remember Me functionality (v0.3.2-beta))
+}
+
+// RefreshToken represents a refresh token for "Remember Me" functionality
+type RefreshToken struct {
+	ID         int64      `json:"id" db:"id"`
+	UserID     int64      `json:"user_id" db:"user_id"`
+	Token      string     `json:"token" db:"token"`
+	ExpiresAt  time.Time  `json:"expires_at" db:"expires_at"`
+	CreatedAt  time.Time  `json:"created_at" db:"created_at"`
+	RevokedAt  *time.Time `json:"revoked_at,omitempty" db:"revoked_at"`
+	DeviceInfo string     `json:"device_info,omitempty" db:"device_info"`
 }
 
 // UserRepository defines the interface for user data access
@@ -35,4 +60,15 @@ type UserRepository interface {
 	Delete(id int64) error
 	List(limit, offset int) ([]*User, error)
 	Count() (int64, error)
+}
+
+// RefreshTokenRepository defines the interface for refresh token data access
+type RefreshTokenRepository interface {
+	Create(token *RefreshToken) error
+	GetByToken(token string) (*RefreshToken, error)
+	GetByUserID(userID int64) ([]*RefreshToken, error)
+	Revoke(tokenID int64) error
+	RevokeAllForUser(userID int64) error
+	DeleteExpired() error
+	Delete(tokenID int64) error
 }

--- a/internal/repository/refresh_token_repository.go
+++ b/internal/repository/refresh_token_repository.go
@@ -1,0 +1,169 @@
+package repository
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/johnzastrow/actalog/internal/domain"
+)
+
+// SQLiteRefreshTokenRepository implements RefreshTokenRepository for SQLite
+type SQLiteRefreshTokenRepository struct {
+	db *sql.DB
+}
+
+// NewSQLiteRefreshTokenRepository creates a new SQLite refresh token repository
+func NewSQLiteRefreshTokenRepository(db *sql.DB) domain.RefreshTokenRepository {
+	return &SQLiteRefreshTokenRepository{db: db}
+}
+
+// Create creates a new refresh token
+func (r *SQLiteRefreshTokenRepository) Create(token *domain.RefreshToken) error {
+	query := `
+		INSERT INTO refresh_tokens (user_id, token, expires_at, created_at, device_info)
+		VALUES (?, ?, ?, ?, ?)
+	`
+
+	result, err := r.db.Exec(query,
+		token.UserID,
+		token.Token,
+		token.ExpiresAt,
+		token.CreatedAt,
+		token.DeviceInfo,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create refresh token: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("failed to get last insert id: %w", err)
+	}
+
+	token.ID = id
+	return nil
+}
+
+// GetByToken retrieves a refresh token by its token string
+func (r *SQLiteRefreshTokenRepository) GetByToken(tokenStr string) (*domain.RefreshToken, error) {
+	query := `
+		SELECT id, user_id, token, expires_at, created_at, revoked_at, device_info
+		FROM refresh_tokens
+		WHERE token = ? AND revoked_at IS NULL AND expires_at > datetime('now')
+	`
+
+	token := &domain.RefreshToken{}
+	err := r.db.QueryRow(query, tokenStr).Scan(
+		&token.ID,
+		&token.UserID,
+		&token.Token,
+		&token.ExpiresAt,
+		&token.CreatedAt,
+		&token.RevokedAt,
+		&token.DeviceInfo,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get refresh token: %w", err)
+	}
+
+	return token, nil
+}
+
+// GetByUserID retrieves all refresh tokens for a user
+func (r *SQLiteRefreshTokenRepository) GetByUserID(userID int64) ([]*domain.RefreshToken, error) {
+	query := `
+		SELECT id, user_id, token, expires_at, created_at, revoked_at, device_info
+		FROM refresh_tokens
+		WHERE user_id = ? AND revoked_at IS NULL
+		ORDER BY created_at DESC
+	`
+
+	rows, err := r.db.Query(query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query refresh tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var tokens []*domain.RefreshToken
+	for rows.Next() {
+		token := &domain.RefreshToken{}
+		err := rows.Scan(
+			&token.ID,
+			&token.UserID,
+			&token.Token,
+			&token.ExpiresAt,
+			&token.CreatedAt,
+			&token.RevokedAt,
+			&token.DeviceInfo,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan refresh token: %w", err)
+		}
+		tokens = append(tokens, token)
+	}
+
+	return tokens, nil
+}
+
+// Revoke revokes a specific refresh token
+func (r *SQLiteRefreshTokenRepository) Revoke(tokenID int64) error {
+	query := `
+		UPDATE refresh_tokens
+		SET revoked_at = datetime('now')
+		WHERE id = ?
+	`
+
+	_, err := r.db.Exec(query, tokenID)
+	if err != nil {
+		return fmt.Errorf("failed to revoke refresh token: %w", err)
+	}
+
+	return nil
+}
+
+// RevokeAllForUser revokes all refresh tokens for a user
+func (r *SQLiteRefreshTokenRepository) RevokeAllForUser(userID int64) error {
+	query := `
+		UPDATE refresh_tokens
+		SET revoked_at = datetime('now')
+		WHERE user_id = ? AND revoked_at IS NULL
+	`
+
+	_, err := r.db.Exec(query, userID)
+	if err != nil {
+		return fmt.Errorf("failed to revoke all refresh tokens: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteExpired deletes all expired refresh tokens
+func (r *SQLiteRefreshTokenRepository) DeleteExpired() error {
+	query := `
+		DELETE FROM refresh_tokens
+		WHERE expires_at < datetime('now')
+	`
+
+	_, err := r.db.Exec(query)
+	if err != nil {
+		return fmt.Errorf("failed to delete expired refresh tokens: %w", err)
+	}
+
+	return nil
+}
+
+// Delete deletes a specific refresh token
+func (r *SQLiteRefreshTokenRepository) Delete(tokenID int64) error {
+	query := `DELETE FROM refresh_tokens WHERE id = ?`
+
+	_, err := r.db.Exec(query, tokenID)
+	if err != nil {
+		return fmt.Errorf("failed to delete refresh token: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,7 @@ const (
 	// Minor version number
 	Minor = 3
 	// Patch version number
-	Patch = 1
+	Patch = 2
 	// PreRelease identifier (e.g., "alpha", "beta", "rc1")
 	PreRelease = "beta"
 )

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actalog-web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ActaLog - CrossFit Workout Tracker",
   "private": true,
   "type": "module",

--- a/web/src/stores/auth.js
+++ b/web/src/stores/auth.js
@@ -5,6 +5,7 @@ import axios from '@/utils/axios'
 export const useAuthStore = defineStore('auth', () => {
   const user = ref(null)
   const token = ref(localStorage.getItem('token') || null)
+  const refreshToken = ref(localStorage.getItem('refreshToken') || null)
   const loading = ref(false)
   const error = ref(null)
 
@@ -24,17 +25,27 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  async function login(email, password) {
+  async function login(email, password, rememberMe = false) {
     loading.value = true
     error.value = null
     try {
-      const response = await axios.post('/api/auth/login', { email, password })
+      const response = await axios.post('/api/auth/login', {
+        email,
+        password,
+        remember_me: rememberMe
+      })
       token.value = response.data.token
       user.value = response.data.user
 
       // Save to localStorage
       localStorage.setItem('token', token.value)
       localStorage.setItem('user', JSON.stringify(user.value))
+
+      // Save refresh token if provided (when remember_me is true)
+      if (response.data.refresh_token) {
+        refreshToken.value = response.data.refresh_token
+        localStorage.setItem('refreshToken', refreshToken.value)
+      }
 
       // Set default authorization header
       axios.defaults.headers.common['Authorization'] = `Bearer ${token.value}`
@@ -70,12 +81,54 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  function logout() {
+  async function logout() {
+    // Revoke refresh token if it exists
+    if (refreshToken.value) {
+      try {
+        await axios.post('/api/auth/revoke', {
+          refresh_token: refreshToken.value
+        })
+      } catch (e) {
+        // Ignore errors during revocation
+        console.error('Failed to revoke refresh token:', e)
+      }
+    }
+
     user.value = null
     token.value = null
+    refreshToken.value = null
     localStorage.removeItem('token')
     localStorage.removeItem('user')
+    localStorage.removeItem('refreshToken')
     delete axios.defaults.headers.common['Authorization']
+  }
+
+  async function refreshAccessToken() {
+    if (!refreshToken.value) {
+      return false
+    }
+
+    try {
+      const response = await axios.post('/api/auth/refresh', {
+        refresh_token: refreshToken.value
+      })
+
+      token.value = response.data.token
+      user.value = response.data.user
+
+      // Update localStorage
+      localStorage.setItem('token', token.value)
+      localStorage.setItem('user', JSON.stringify(user.value))
+
+      // Set default authorization header
+      axios.defaults.headers.common['Authorization'] = `Bearer ${token.value}`
+
+      return true
+    } catch (e) {
+      // Refresh token is invalid or expired, logout
+      logout()
+      return false
+    }
   }
 
   async function updateProfile(updates) {
@@ -100,12 +153,14 @@ export const useAuthStore = defineStore('auth', () => {
   return {
     user,
     token,
+    refreshToken,
     loading,
     error,
     isAuthenticated,
     login,
     register,
     logout,
+    refreshAccessToken,
     updateProfile
   }
 })

--- a/web/src/utils/axios.js
+++ b/web/src/utils/axios.js
@@ -24,22 +24,101 @@ instance.interceptors.request.use(
   }
 )
 
+// Track if we're currently refreshing the token
+let isRefreshing = false
+let failedQueue = []
+
+const processQueue = (error, token = null) => {
+  failedQueue.forEach(prom => {
+    if (error) {
+      prom.reject(error)
+    } else {
+      prom.resolve(token)
+    }
+  })
+  failedQueue = []
+}
+
 // Response interceptor
 instance.interceptors.response.use(
   (response) => {
     return response
   },
-  (error) => {
-    if (error.response) {
-      // Handle 401 Unauthorized
-      if (error.response.status === 401) {
-        // Clear auth data
+  async (error) => {
+    const originalRequest = error.config
+
+    // Handle 401 Unauthorized
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      // Check if this is the refresh endpoint failing
+      if (originalRequest.url === '/api/auth/refresh') {
+        // Refresh token is invalid/expired, clear everything and redirect
         localStorage.removeItem('token')
         localStorage.removeItem('user')
-        // Redirect to login
+        localStorage.removeItem('refreshToken')
         window.location.href = '/login'
+        return Promise.reject(error)
+      }
+
+      // If we're already refreshing, queue this request
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject })
+        }).then(token => {
+          originalRequest.headers.Authorization = `Bearer ${token}`
+          return instance(originalRequest)
+        }).catch(err => {
+          return Promise.reject(err)
+        })
+      }
+
+      originalRequest._retry = true
+      isRefreshing = true
+
+      const refreshToken = localStorage.getItem('refreshToken')
+
+      if (!refreshToken) {
+        // No refresh token available, redirect to login
+        localStorage.removeItem('token')
+        localStorage.removeItem('user')
+        window.location.href = '/login'
+        return Promise.reject(error)
+      }
+
+      try {
+        // Attempt to refresh the access token
+        const response = await instance.post('/api/auth/refresh', {
+          refresh_token: refreshToken
+        })
+
+        const newToken = response.data.token
+        const newUser = response.data.user
+
+        // Update localStorage
+        localStorage.setItem('token', newToken)
+        localStorage.setItem('user', JSON.stringify(newUser))
+
+        // Update the authorization header
+        instance.defaults.headers.common['Authorization'] = `Bearer ${newToken}`
+        originalRequest.headers.Authorization = `Bearer ${newToken}`
+
+        // Process queued requests
+        processQueue(null, newToken)
+
+        // Retry the original request
+        return instance(originalRequest)
+      } catch (refreshError) {
+        // Refresh failed, clear everything and redirect
+        processQueue(refreshError, null)
+        localStorage.removeItem('token')
+        localStorage.removeItem('user')
+        localStorage.removeItem('refreshToken')
+        window.location.href = '/login'
+        return Promise.reject(refreshError)
+      } finally {
+        isRefreshing = false
       }
     }
+
     return Promise.reject(error)
   }
 )

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -31,6 +31,14 @@
                 class="mt-4"
               />
 
+              <v-checkbox
+                v-model="rememberMe"
+                label="Remember me for 30 days"
+                color="primary"
+                hide-details
+                class="mt-2"
+              />
+
               <v-btn
                 type="submit"
                 color="primary"
@@ -71,6 +79,7 @@ const authStore = useAuthStore()
 
 const email = ref('')
 const password = ref('')
+const rememberMe = ref(false)
 const loading = ref(false)
 const errors = ref({})
 
@@ -78,7 +87,7 @@ const handleLogin = async () => {
   errors.value = {}
   loading.value = true
 
-  const success = await authStore.login(email.value, password.value)
+  const success = await authStore.login(email.value, password.value, rememberMe.value)
 
   if (success) {
     router.push('/dashboard')


### PR DESCRIPTION
Implement complete "Remember Me" functionality with refresh tokens:

Backend:
- Add database migration v0.3.2 for refresh_tokens table
- Create RefreshToken domain model and repository interface
- Implement SQLiteRefreshTokenRepository with CRUD operations
- Add UserService methods: CreateRefreshToken, RefreshAccessToken, RevokeRefreshToken, RevokeAllRefreshTokens, GetUserRefreshTokens
- Add JWT_REFRESH_DURATION config (default: 30 days)
- Wire up API endpoints: POST /api/auth/refresh, POST /api/auth/revoke
- Update Login handler to create refresh token when remember_me=true
- Fix User.ProfileImage field to be *string to handle NULL values

Frontend:
- Add "Remember Me" checkbox to LoginView (30 days)
- Update auth store to handle refresh tokens in localStorage
- Implement auto-refresh logic in axios interceptor
- Add logout revoke functionality

Security:
- Secure token generation using crypto/rand (32 bytes, 256 bits)
- Token expiration and revocation support
- Device tracking via User-Agent header
- Request queueing during token refresh to prevent race conditions