### PR TITLE
feat: Add user profile editing with birthday field (v0.3.3-beta)

### DIFF
--- a/cmd/actalog/main.go
+++ b/cmd/actalog/main.go
@@ -145,6 +145,7 @@ func main() {
 
 	// Initialize handlers
 	authHandler := handler.NewAuthHandler(userService)
+	userHandler := handler.NewUserHandler(userService)
 	movementHandler := handler.NewMovementHandler(movementRepo)
 	workoutHandler := handler.NewWorkoutHandler(workoutRepo, workoutMovementRepo, workoutService)
 
@@ -199,6 +200,10 @@ func main() {
 
 			// Movement management (authenticated)
 			r.Post("/movements", movementHandler.Create)
+
+			// User profile routes (authenticated)
+			r.Get("/users/profile", userHandler.GetProfile)
+			r.Put("/users/profile", userHandler.UpdateProfile)
 
 			// Workout routes (authenticated)
 			r.Post("/workouts", workoutHandler.Create)

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -12,6 +12,7 @@ type User struct {
 	PasswordHash                string     `json:"-" db:"password_hash"` // Never serialize password
 	Name                        string     `json:"name" db:"name"`
 	ProfileImage                *string    `json:"profile_image,omitempty" db:"profile_image"`
+	Birthday                    *time.Time `json:"birthday,omitempty" db:"birthday"`
 	Role                        string     `json:"role" db:"role"` // user, admin
 	EmailVerified               bool       `json:"email_verified" db:"email_verified"`
 	EmailVerifiedAt             *time.Time `json:"email_verified_at,omitempty" db:"email_verified_at"`

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/johnzastrow/actalog/internal/service"

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -1,0 +1,104 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/johnzastrow/actalog/internal/service"
+	"github.com/johnzastrow/actalog/pkg/middleware"
+)
+
+// UserHandler handles user profile endpoints
+type UserHandler struct {
+	userService *service.UserService
+}
+
+// NewUserHandler creates a new user handler
+func NewUserHandler(userService *service.UserService) *UserHandler {
+	return &UserHandler{
+		userService: userService,
+	}
+}
+
+// UpdateProfileRequest represents a profile update request
+type UpdateProfileRequest struct {
+	Name     string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Birthday string `json:"birthday,omitempty"` // Format: "YYYY-MM-DD" or empty
+}
+
+// ProfileResponse represents a profile response
+type ProfileResponse struct {
+	User interface{} `json:"user"`
+}
+
+// UpdateProfile handles profile update requests
+func (h *UserHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
+	// Get user ID from context (set by auth middleware)
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		respondError(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	var req UpdateProfileRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	// Parse birthday if provided
+	var birthday *time.Time
+	if req.Birthday != "" {
+		parsedBirthday, err := time.Parse("2006-01-02", req.Birthday)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, "Invalid birthday format. Use YYYY-MM-DD")
+			return
+		}
+		birthday = &parsedBirthday
+	}
+
+	// Update profile
+	user, err := h.userService.UpdateProfile(userID, req.Name, req.Email, birthday)
+	if err != nil {
+		switch err {
+		case service.ErrEmailAlreadyExists:
+			respondError(w, http.StatusConflict, "Email already in use")
+		case service.ErrUserNotFound:
+			respondError(w, http.StatusNotFound, "User not found")
+		default:
+			respondError(w, http.StatusInternalServerError, "Failed to update profile")
+		}
+		return
+	}
+
+	respondJSON(w, http.StatusOK, ProfileResponse{
+		User: user,
+	})
+}
+
+// GetProfile retrieves the current user's profile
+func (h *UserHandler) GetProfile(w http.ResponseWriter, r *http.Request) {
+	// Get user ID from context (set by auth middleware)
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		respondError(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	// Get user from service
+	user, err := h.userService.GetByID(userID)
+	if err != nil {
+		if err == service.ErrUserNotFound {
+			respondError(w, http.StatusNotFound, "User not found")
+		} else {
+			respondError(w, http.StatusInternalServerError, "Failed to get profile")
+		}
+		return
+	}
+
+	respondJSON(w, http.StatusOK, ProfileResponse{
+		User: user,
+	})
+}

--- a/internal/repository/migrations.go
+++ b/internal/repository/migrations.go
@@ -282,6 +282,46 @@ var migrations = []Migration{
 			return err
 		},
 	},
+	{
+		Version:     "0.3.3",
+		Description: "Add birthday field to users table for profile editing",
+		Up: func(db *sql.DB, driver string) error {
+			var query string
+			switch driver {
+			case "sqlite3":
+				query = "ALTER TABLE users ADD COLUMN birthday DATE"
+			case "postgres":
+				query = "ALTER TABLE users ADD COLUMN birthday DATE"
+			case "mysql":
+				query = "ALTER TABLE users ADD COLUMN birthday DATE"
+			default:
+				return fmt.Errorf("unsupported database driver: %s", driver)
+			}
+
+			_, err := db.Exec(query)
+			if err != nil {
+				return fmt.Errorf("failed to add birthday column: %w", err)
+			}
+			return nil
+		},
+		Down: func(db *sql.DB, driver string) error {
+			var query string
+			switch driver {
+			case "sqlite3":
+				// SQLite doesn't support DROP COLUMN directly, would need table recreation
+				return fmt.Errorf("SQLite does not support dropping columns")
+			case "postgres":
+				query = "ALTER TABLE users DROP COLUMN birthday"
+			case "mysql":
+				query = "ALTER TABLE users DROP COLUMN birthday"
+			default:
+				return fmt.Errorf("unsupported database driver: %s", driver)
+			}
+
+			_, err := db.Exec(query)
+			return err
+		},
+	},
 }
 
 // RunMigrations runs all pending migrations

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -7,6 +7,69 @@
       </v-col>
 
       <v-col cols="12">
+        <!-- Profile Editing Section -->
+        <v-card elevation="2" rounded="lg" class="mb-4">
+          <v-card-title>Profile Information</v-card-title>
+          <v-card-text>
+            <v-form @submit.prevent="updateProfile">
+              <v-text-field
+                v-model="profileForm.name"
+                label="Name"
+                prepend-inner-icon="mdi-account"
+                :error-messages="errors.name"
+              />
+
+              <v-text-field
+                v-model="profileForm.email"
+                label="Email"
+                type="email"
+                prepend-inner-icon="mdi-email"
+                :error-messages="errors.email"
+                hint="Changing your email will require re-verification"
+              />
+
+              <v-text-field
+                v-model="profileForm.birthday"
+                label="Birthday"
+                type="date"
+                prepend-inner-icon="mdi-cake-variant"
+                :error-messages="errors.birthday"
+              />
+
+              <v-alert
+                v-if="successMessage"
+                type="success"
+                class="mt-4"
+                closable
+                @click:close="successMessage = ''"
+              >
+                {{ successMessage }}
+              </v-alert>
+
+              <v-alert
+                v-if="errors.general"
+                type="error"
+                class="mt-4"
+                closable
+                @click:close="errors.general = ''"
+              >
+                {{ errors.general }}
+              </v-alert>
+
+              <v-btn
+                type="submit"
+                color="primary"
+                block
+                size="large"
+                class="mt-4"
+                :loading="loading"
+              >
+                Update Profile
+              </v-btn>
+            </v-form>
+          </v-card-text>
+        </v-card>
+
         <v-card elevation="2" rounded="lg" class="mb-4">
           <v-card-title>Preferences</v-card-title>
           <v-card-text>
@@ -53,8 +116,83 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import axios from '@/utils/axios'
+
+const authStore = useAuthStore()
 
 const darkMode = ref(false)
 const notifications = ref(true)
+
+const profileForm = ref({
+  name: '',
+  email: '',
+  birthday: ''
+})
+
+const loading = ref(false)
+const successMessage = ref('')
+const errors = ref({})
+
+// Load current user data
+onMounted(() => {
+  if (authStore.user) {
+    profileForm.value.name = authStore.user.name || ''
+    profileForm.value.email = authStore.user.email || ''
+
+    // Format birthday if it exists (from ISO to YYYY-MM-DD)
+    if (authStore.user.birthday) {
+      const date = new Date(authStore.user.birthday)
+      profileForm.value.birthday = date.toISOString().split('T')[0]
+    }
+  }
+})
+
+const updateProfile = async () => {
+  errors.value = {}
+  successMessage.value = ''
+
+  // Basic validation
+  if (!profileForm.value.name) {
+    errors.value.name = 'Name is required'
+    return
+  }
+
+  if (!profileForm.value.email) {
+    errors.value.email = 'Email is required'
+    return
+  }
+
+  loading.value = true
+
+  try {
+    const response = await axios.put('/api/users/profile', {
+      name: profileForm.value.name,
+      email: profileForm.value.email,
+      birthday: profileForm.value.birthday || undefined
+    })
+
+    if (response.status === 200) {
+      // Update the auth store with new user data
+      authStore.user = response.data.user
+      successMessage.value = 'Profile updated successfully!'
+
+      // If email changed, show additional message
+      if (response.data.user.email !== authStore.user.email) {
+        successMessage.value += ' Please check your email to verify your new address.'
+      }
+    }
+  } catch (error) {
+    if (error.response?.status === 409) {
+      errors.value.email = 'Email already in use by another account'
+    } else if (error.response?.status === 400) {
+      errors.value.general = error.response.data.message || 'Invalid input'
+    } else {
+      errors.value.general = 'Failed to update profile. Please try again.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
 </script>


### PR DESCRIPTION
This commit implements comprehensive user profile editing functionality:

**Database Changes:**
- Migration v0.3.3: Add nullable birthday field (DATE type) to users table
- Supports SQLite, PostgreSQL, and MySQL

**Backend Changes:**
- Add Birthday field to User domain model
- Implement UpdateProfile service method with:
  - Name, email, and birthday updates
  - Email change triggers re-verification
  - Email uniqueness validation
- Create UserHandler with GetProfile and UpdateProfile endpoints
- Wire up /api/users/profile routes (GET, PUT)
- Remove unused import from auth_handler.go

**Frontend Changes:**
- Enhance SettingsView with profile editing form
- Form fields: name (text), email (email), birthday (date)
- Auto-populate from current user data
- Success/error messaging
- Email change warning (requires re-verification)
- Integrates with auth store

**API Endpoints:**
- GET /api/users/profile - Get current user profile
- PUT /api/users/profile - Update profile (name, email, birthday)

**Testing:**
- Backend build successful
- Migrations applied successfully
- API endpoints verified with curl
- Frontend build successful

Closes user profile editing feature request.