### PR TITLE
v1.2.4 — security hardening, part two

### DIFF
--- a/.github/workflows/ci-failure-notify.yml
+++ b/.github/workflows/ci-failure-notify.yml
@@ -46,10 +46,91 @@ jobs:
           *This issue was created automatically by the CI Failure Notify workflow.*
           EOF
 
-      - name: Create issue for failed CI run
-        uses: peter-evans/create-issue-from-file@v6
+      - name: Create or update issue for failed CI run
+        uses: actions/github-script@v8
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
-          title: "[CI] Workflow failure: ${{ github.event.workflow_run.name }} on ${{ github.event.workflow_run.head_branch }}"
-          content-filepath: /tmp/ci_issue.md
-          labels: ci,failure,auto
-          assignees: ""
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/ci_issue.md', 'utf8');
+            const title = `[CI] Workflow failure: ${process.env.WORKFLOW_NAME} on ${process.env.HEAD_BRANCH}`;
+
+            // Re-use the existing tracking issue for the same workflow+branch
+            // pair instead of spawning a duplicate on every rebase. Filtered
+            // to the auto-failure label set so only bot-managed issues match.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci,failure,auto',
+              per_page: 100,
+            });
+            const match = existing.data.find(i => i.title === title);
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Another CI run failed on this branch. Latest details:\n\n${body}`,
+              });
+              core.info(`Updated existing issue #${match.number} instead of creating a duplicate.`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['ci', 'failure', 'auto'],
+              });
+              core.info(`Created issue #${created.data.number}.`);
+            }
+
+  close-issue-on-success:
+    # When a previously-failing branch's next CI run succeeds, close the
+    # tracking issue so it doesn't linger after the underlying problem
+    # has been resolved (Dependabot rebase, manual fix pushed, etc.).
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Close tracking issue if it exists
+        uses: actions/github-script@v8
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        with:
+          script: |
+            const title = `[CI] Workflow failure: ${process.env.WORKFLOW_NAME} on ${process.env.HEAD_BRANCH}`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci,failure,auto',
+              per_page: 100,
+            });
+            const match = existing.data.find(i => i.title === title);
+            if (!match) {
+              core.info(`No open tracking issue to close.`);
+              return;
+            }
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.RUN_ID}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: match.number,
+              body: `Auto-closing: a subsequent CI run on this branch succeeded. Run: ${runUrl}`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: match.number,
+              state: 'closed',
+              state_reason: 'completed',
+            });
+            core.info(`Closed issue #${match.number}.`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ ActaLog is a mobile-first CrossFit workout tracker built with:
 - **Frontend:** Vue.js 3, Vuetify 3, Pinia
 - **Architecture:** Clean Architecture with strict layer separation
 
-**Version:** 1.2.3
+**Version:** 1.2.4
 
 ## Quick Reference
 
@@ -135,10 +135,10 @@ When testing new features, cycle through all supported databases to ensure compa
 
 # Tag and push to registry (always push to dev, latest, and version tags)
 docker tag ghcr.io/johnzastrow/actalog:dev ghcr.io/johnzastrow/actalog:latest
-docker tag ghcr.io/johnzastrow/actalog:dev ghcr.io/johnzastrow/actalog:1.2.3  # Use current version
+docker tag ghcr.io/johnzastrow/actalog:dev ghcr.io/johnzastrow/actalog:1.2.4  # Use current version
 ./docker/scripts/push.sh dev
 ./docker/scripts/push.sh latest
-./docker/scripts/push.sh 1.2.3  # Use current version
+./docker/scripts/push.sh 1.2.4  # Use current version
 
 # Test with SQLite (mount local data directory)
 docker run -p 8080:8080 -v $(pwd)/data:/app/data \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A mobile-first fitness tracker for CrossFit enthusiasts to log workouts, track progress, and analyze performance.
 
-[![Version](https://img.shields.io/badge/version-1.2.3-blue)](https://github.com/johnzastrow/actalog/blob/main/docs/CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.2.4-blue)](https://github.com/johnzastrow/actalog/blob/main/docs/CHANGELOG.md)
 [![Docker Image](https://img.shields.io/badge/Docker-ghcr.io%2Fjohnzastrow%2Factalog-2496ED?style=flat&logo=docker)](https://github.com/johnzastrow/actalog/pkgs/container/actalog)
 [![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://golang.org)
 [![Vue.js](https://img.shields.io/badge/Vue.js-3.x-4FC08D?style=flat&logo=vue.js)](https://vuejs.org)
@@ -44,7 +44,7 @@ docker pull ghcr.io/johnzastrow/actalog:latest
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable build |
-| `v1.2.3` | Current versioned release |
+| `v1.2.4` | Current versioned release |
 | `dev` | Development build |
 
 **Run with SQLite (simplest):**

--- a/cmd/actalog/main.go
+++ b/cmd/actalog/main.go
@@ -574,6 +574,7 @@ func main() {
 	// Middleware
 	r.Use(middleware.LoggingMiddleware(appLogger))
 	r.Use(middleware.CORS(cfg.App.CORSOrigins))
+	r.Use(middleware.SecurityHeaders)
 
 	// Health check endpoint
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to ActaLog will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-04-28 — Security hardening, part two
+
+Closes the two items deferred from v1.2.3 (`docs/plans/SECURITY_HARDENING_PLAN.md` Steps 2 and 5).
+
+### Security
+- **Security response headers middleware** — new `pkg/middleware/SecurityHeaders` sets `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Strict-Transport-Security: max-age=31536000; includeSubDomains`, and a project-tuned `Content-Security-Policy` on every response. Wired in `cmd/actalog/main.go` after the CORS middleware so it applies to API, static assets, and `/health`. CSP allows `'unsafe-inline'` for *styles* (Vuetify dynamic theme injection requires it) but keeps scripts strict (`script-src 'self'` only)
+- **Avatar upload magic-byte validation** — `internal/handler/user_handler.go` no longer trusts the client-supplied `Content-Type` header. The first 512 bytes of the uploaded file are read and passed to `http.DetectContentType` (WHATWG MIME Sniffing); the file pointer is then rewound for the subsequent copy. A filename-extension allowlist (`.jpg/.jpeg/.png/.gif/.webp`) closes the residual stored-XSS path where image magic bytes could be uploaded under a `.html` filename and later served with a `text/html` content-type by the static file handler
+- New negative tests cover the spoofed-Content-Type and disallowed-extension cases
+
+### CI
+- **CI Failure Notify workflow now deduplicates and auto-closes.** Previously every CI failure (including each Dependabot rebase) opened a fresh `[CI] Workflow failure: ...` issue; old issues never closed. The workflow now (a) re-uses an existing tracking issue with the same `(workflow, branch)` title instead of spawning duplicates, and (b) on the next *successful* CI run for the same branch, closes the tracking issue with a comment linking the green run. Switched from `peter-evans/create-issue-from-file` to `actions/github-script` to access the issue list/update REST endpoints
+
+### Maintenance
+- Eight Dependabot bumps merged: actions/deploy-pages 4→5, docker/setup-buildx-action 3→4, lib/pq 1.12.1→1.12.3, x/crypto 0.49.0→0.50.0, pgx 5.9.1→5.9.2, vue-ecosystem group, go-sqlite3 1.14.38→1.14.42, dev-dependencies group (8 npm updates)
+- Two Dependabot PRs closed with policy comments: Vuetify 4.0.5 (held by watch-and-wait policy until 4.1.x), axios 1.14.0 (post supply-chain compromise; close-and-wait until npm reissues clean 1.14.x or 1.15.x ships)
+
+---
+
 ## [1.2.3] - 2026-04-03 — Security hardening release
 
 ### Security

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -235,9 +235,9 @@ The following lint issues need to be resolved to re-enable strict linting:
   - **Performance:** `font-display: swap`, service worker caching, only selected font loads 
 
 
-#### Security (carried over from v1.2.3 hardening branch)
-- [ ] `[HIGH]` **Security Response Headers Middleware** — Add `pkg/middleware/security_headers.go` setting `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Strict-Transport-Security: max-age=31536000; includeSubDomains`, and a starting CSP (`default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; ...`). Wire after CORS in `cmd/actalog/main.go`. Add `security_headers_test.go`. Plan: `docs/plans/SECURITY_HARDENING_PLAN.md` Step 2 (~2 hr).
-- [ ] `[HIGH]` **Avatar Upload Magic-Byte Validation** — Replace the `Content-Type` header check at `internal/handler/user_handler.go:220-223` with `http.DetectContentType()` against the first 512 bytes, plus an extension allowlist (`.jpg/.jpeg/.png/.gif/.webp`). Required because the current check trusts a header the client controls. Plan: `docs/plans/SECURITY_HARDENING_PLAN.md` Step 5 (~1 hr).
+#### Security (closed in v1.2.4 hardening branch)
+- [x] `[HIGH]` **Security Response Headers Middleware** *(Completed v1.2.4)* — Added `pkg/middleware/security_headers.go` setting X-Frame-Options, X-Content-Type-Options, Referrer-Policy, HSTS, and a project-tuned CSP. Wired after CORS in `cmd/actalog/main.go`. Tests in `security_headers_test.go` assert per-header values and that script-src stays free of `'unsafe-inline'`/`'unsafe-eval'`.
+- [x] `[HIGH]` **Avatar Upload Magic-Byte Validation** *(Completed v1.2.4)* — Replaced trust-the-header check with `http.DetectContentType()` over the first 512 bytes plus a `.jpg/.jpeg/.png/.gif/.webp` extension allowlist. Negative tests cover spoofed-Content-Type and disallowed-extension cases.
 
 #### Backend Improvements
 - [x] `[HIGH]` **Backup and Restore** make sure the backup functions keep up with the database schema changes (tested backup and restore round trips on SQLite, PostgreSQL, and MariaDB).
@@ -523,6 +523,18 @@ These features can be added after the core frontend is complete:
 ---
 
 ## Completed Releases
+
+### v1.2.4 (2026-04-28 — Security Hardening, part two)
+
+**Status:** Released from `security/headers-and-uploads-2026-04-28`. Closes the two items deferred from v1.2.3.
+
+**Completed:**
+- [x] **Security** — Security response headers middleware (`pkg/middleware/security_headers.go`) sets X-Frame-Options, X-Content-Type-Options, Referrer-Policy, HSTS, and a project-tuned CSP on every response; wired after CORS in `cmd/actalog/main.go`
+- [x] **Security** — Avatar upload no longer trusts client `Content-Type`; uses `http.DetectContentType` over first 512 bytes plus extension allowlist (`internal/handler/user_handler.go`)
+- [x] **CI** — CI Failure Notify workflow now deduplicates issues per (workflow, branch) and auto-closes when a subsequent run on the same branch succeeds (`.github/workflows/ci-failure-notify.yml`)
+- [x] **Maintenance** — 8 Dependabot bumps merged (deploy-pages, setup-buildx, lib/pq, x/crypto, pgx, vue-ecosystem, go-sqlite3, dev-dependencies group); 2 closed with policy comments (Vuetify 4.0.5 watch-and-wait, axios 1.14.0 supply-chain)
+
+---
 
 ### v1.2.3 (2026-04-03 — Security Hardening)
 

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -216,10 +216,33 @@ func (h *UserHandler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	// Validate file type
-	contentType := header.Header.Get("Content-Type")
-	if !strings.HasPrefix(contentType, "image/") {
+	// Validate file type by sniffing the actual bytes — never trust the
+	// client-supplied Content-Type header. http.DetectContentType implements
+	// the WHATWG MIME Sniffing algorithm and reads up to 512 bytes.
+	sniff := make([]byte, 512)
+	n, err := file.Read(sniff)
+	if err != nil && err != io.EOF {
+		respondError(w, http.StatusBadRequest, "Failed to read uploaded file")
+		return
+	}
+	detectedType := http.DetectContentType(sniff[:n])
+	if !strings.HasPrefix(detectedType, "image/") {
 		respondError(w, http.StatusBadRequest, "File must be an image")
+		return
+	}
+	// Rewind so the subsequent io.Copy writes the whole file, not just the
+	// bytes after the sniff buffer.
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		respondError(w, http.StatusInternalServerError, "Failed to process file")
+		return
+	}
+
+	// Validate extension against an allowlist. Magic-byte sniffing alone does
+	// not stop a JPEG payload uploaded under a .html filename, which the
+	// static file server would later serve with a text/html content-type.
+	allowedExts := map[string]bool{".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".webp": true}
+	if !allowedExts[strings.ToLower(filepath.Ext(header.Filename))] {
+		respondError(w, http.StatusBadRequest, "Only jpg, png, gif, and webp images are allowed")
 		return
 	}
 

--- a/internal/handler/user_handler_test.go
+++ b/internal/handler/user_handler_test.go
@@ -264,6 +264,42 @@ func TestUserHandler_UploadAvatar_ApplicationPDF(t *testing.T) {
 	assertBodyContains(t, rr, "File must be an image")
 }
 
+func TestUserHandler_UploadAvatar_SpoofedContentType(t *testing.T) {
+	handler := &UserHandler{
+		logger: createTestLogger(),
+	}
+
+	// Filename and Content-Type both claim image/png, but bytes are HTML.
+	// Magic-byte sniffing must override the client-supplied header.
+	fileContent := []byte("<script>alert('xss')</script>")
+	req := createMultipartRequest(http.MethodPost, "/api/profile/avatar", "avatar", "evil.png", "image/png", fileContent, 1, "test@example.com", "user")
+	rr := httptest.NewRecorder()
+
+	handler.UploadAvatar(rr, req)
+
+	assertStatusCode(t, rr, http.StatusBadRequest)
+	assertBodyContains(t, rr, "File must be an image")
+}
+
+func TestUserHandler_UploadAvatar_DisallowedExtensionWithImageBytes(t *testing.T) {
+	handler := &UserHandler{
+		logger: createTestLogger(),
+	}
+
+	// Valid PNG magic bytes but a .html filename. Magic-byte sniffing alone
+	// would let this through; the extension allowlist is what stops the
+	// stored-XSS attack vector via a later /uploads/... navigation.
+	pngMagic := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	pngBody := append(pngMagic, []byte("rest of png data ...")...)
+	req := createMultipartRequest(http.MethodPost, "/api/profile/avatar", "avatar", "evil.html", "image/png", pngBody, 1, "test@example.com", "user")
+	rr := httptest.NewRecorder()
+
+	handler.UploadAvatar(rr, req)
+
+	assertStatusCode(t, rr, http.StatusBadRequest)
+	assertBodyContains(t, rr, "Only jpg, png, gif, and webp images are allowed")
+}
+
 func TestUserHandler_UploadAvatar_WrongFieldName(t *testing.T) {
 	handler := &UserHandler{
 		logger: createTestLogger(),

--- a/pkg/middleware/security_headers.go
+++ b/pkg/middleware/security_headers.go
@@ -1,0 +1,33 @@
+package middleware
+
+import "net/http"
+
+// defaultCSP is a starting Content-Security-Policy that does not break the Vue 3
+// + Vuetify 3 PWA. `'unsafe-inline'` is needed only for styles because Vuetify
+// injects inline <style> blocks at runtime for theme switching; scripts stay
+// strict. Tighten this further as nonces are introduced.
+const defaultCSP = "default-src 'self'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data: blob:; " +
+	"connect-src 'self'; " +
+	"font-src 'self'; " +
+	"frame-ancestors 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'"
+
+// SecurityHeaders sets a baseline of OWASP-recommended security response
+// headers on every response. Values are conservative defaults; CSP in particular
+// is project-specific and should be re-evaluated as the frontend evolves.
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		h.Set("Content-Security-Policy", defaultCSP)
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/middleware/security_headers_test.go
+++ b/pkg/middleware/security_headers_test.go
@@ -1,0 +1,100 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSecurityHeaders_SetsBaselineHeaders(t *testing.T) {
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cases := []struct {
+		header string
+		want   string
+	}{
+		{"X-Frame-Options", "DENY"},
+		{"X-Content-Type-Options", "nosniff"},
+		{"Referrer-Policy", "strict-origin-when-cross-origin"},
+		{"Strict-Transport-Security", "max-age=31536000; includeSubDomains"},
+	}
+	for _, tc := range cases {
+		if got := rec.Header().Get(tc.header); got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.header, got, tc.want)
+		}
+	}
+}
+
+func TestSecurityHeaders_CSPIncludesRequiredDirectives(t *testing.T) {
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("Content-Security-Policy header is empty")
+	}
+
+	required := []string{
+		"default-src 'self'",
+		"script-src 'self'", // strict — no 'unsafe-inline' or 'unsafe-eval'
+		"frame-ancestors 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+	}
+	for _, directive := range required {
+		if !strings.Contains(csp, directive) {
+			t.Errorf("CSP missing required directive %q\nfull CSP: %s", directive, csp)
+		}
+	}
+
+	// Script source must NOT carry unsafe-inline or unsafe-eval. Check the
+	// script-src directive specifically; 'unsafe-inline' is allowed for styles.
+	scriptDirective := extractDirective(csp, "script-src")
+	for _, forbidden := range []string{"'unsafe-inline'", "'unsafe-eval'"} {
+		if strings.Contains(scriptDirective, forbidden) {
+			t.Errorf("script-src must not contain %s; got %q", forbidden, scriptDirective)
+		}
+	}
+}
+
+func TestSecurityHeaders_PassesThroughHandlerResponse(t *testing.T) {
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("hello"))
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("Status = %d, want %d", rec.Code, http.StatusTeapot)
+	}
+	if rec.Body.String() != "hello" {
+		t.Errorf("Body = %q, want %q", rec.Body.String(), "hello")
+	}
+}
+
+// extractDirective returns the value portion of a single CSP directive, or "" if
+// the directive is not present. Used so tests can assert per-directive content
+// rather than substring-matching the entire CSP string (which would falsely
+// match 'unsafe-inline' on style-src when checking script-src).
+func extractDirective(csp, name string) string {
+	for _, part := range strings.Split(csp, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, name+" ") || part == name {
+			return strings.TrimPrefix(part, name)
+		}
+	}
+	return ""
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,11 +9,11 @@ const (
 	// Minor version number
 	Minor = 2
 	// Patch version number
-	Patch = 3
+	Patch = 4
 	// PreRelease identifier (e.g., "alpha", "beta", "rc1")
 	PreRelease = ""
 	// Build number - increment this with each code change
-	Build = 48
+	Build = 49
 )
 
 // Version returns the full semantic version string

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actalog-web",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "ActaLog - CrossFit Workout Tracker",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Closes the two items deferred from v1.2.3 plus a CI workflow tweak that stops the duplicate-issue spam we lived through this session.

### Security
- **Security response headers middleware** (`pkg/middleware/security_headers.go`) sets X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy strict-origin-when-cross-origin, HSTS one-year + includeSubDomains, and a project-tuned CSP. CSP allows `'unsafe-inline'` for *styles* only (Vuetify dynamic theme injection requires it); scripts stay strict (`script-src 'self'` with no `unsafe-*` tokens). Wired after CORS in `cmd/actalog/main.go` so it covers API, static assets, and `/health`.
- **Avatar upload magic-byte validation** — `internal/handler/user_handler.go` no longer trusts the client `Content-Type` header. Reads first 512 bytes, runs `http.DetectContentType` (WHATWG MIME Sniffing), seeks back so the subsequent `io.Copy` writes the whole file. Plus an extension allowlist (`.jpg/.jpeg/.png/.gif/.webp`) to close the residual stored-XSS path where image bytes uploaded under `evil.html` would be served as `text/html`.

### CI
- **CI Failure Notify** workflow now dedupes and auto-closes:
  - On failure: re-uses any existing tracking issue with the same `(workflow, branch)` title instead of opening a duplicate; comments with the latest run details.
  - On success: closes the tracking issue (if any) for the same `(workflow, branch)` with a comment linking the green run.
  - Switched from `peter-evans/create-issue-from-file` to `actions/github-script` to access the issue list/update REST endpoints. All branch-name interpolation flows through `env:` blocks → `process.env.*` to keep injection-safe.

### Test plan
- [x] `go test ./...` — all 10 packages pass
- [x] `gofmt` clean on all touched files
- [x] New unit tests in `pkg/middleware/security_headers_test.go` (3) and `internal/handler/user_handler_test.go` (2 negative cases for spoofed-CT and disallowed-extension)
- [x] Build clean (`go build ./...`)
- [ ] Browser smoke test — verify Vue PWA loads under the new CSP (themes, fonts, image uploads, markdown)
- [ ] CI matrix on this branch (sqlite3, postgres, mysql)

### Plan / docs
- `docs/plans/SECURITY_HARDENING_PLAN.md` Steps 2 and 5 — both implemented as specified
- TODO `[HIGH]` items "Security Response Headers Middleware" and "Avatar Upload Magic-Byte Validation" both marked complete; v1.2.4 added to Completed Releases

### Manual review tip
The CSP is the highest-risk change to user-visible behaviour. If anything in the PWA breaks under the new policy (uncommon ones: web workers, blob: URLs in scripts, eval in dev tools), tighten or relax `Content-Security-Policy` in `pkg/middleware/security_headers.go:11-19` rather than removing the header entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)