### PR TITLE
fix: nil-email panics + validation 500s in admin user-edit (v1.3.0 hotfix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ Caddyfile
 # Local screenshots and browser-automation artifacts (root only — keeps docs/ and screenshots/ tracked)
 /*.png
 .playwright-mcp/
+
+# Git worktrees for isolated feature/fix development
+.worktrees/

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -15,3 +15,38 @@ var ErrProtectedUser = errors.New("protected user: modifications blocked")
 // Note: this is the domain-layer sentinel. See handler.ErrConflict for
 // the HTTP-layer equivalent (a *HTTPError used by the older MapServiceError pipeline).
 var ErrConflict = errors.New("resource modified concurrently")
+
+// InvalidInputError is the validation-failure type returned by service-layer
+// methods when user-supplied input violates a domain rule (e.g., empty name,
+// future birthday, malformed email). Handlers should surface it as HTTP 400
+// with the embedded message — it is safe to expose because services construct
+// it with human-readable, field-scoped wording.
+//
+// Use a typed value (not a sentinel) so the handler can extract the exact
+// message via errors.As without sniffing strings, and so Field can drive
+// future per-field error UIs without changing the wire format.
+//
+// Example:
+//
+//	if name == "" {
+//	    return nil, &domain.InvalidInputError{Field: "name", Message: "is required"}
+//	}
+//	// → response body: {"message": "name: is required", "error": "invalid_input"}
+type InvalidInputError struct {
+	// Field is the name of the offending input (e.g., "birthday"). Optional —
+	// when empty, Error() returns Message alone.
+	Field string
+	// Message is the human-readable explanation. Required.
+	Message string
+	// Cause is the underlying error, if any (e.g., a parse failure). Optional.
+	Cause error
+}
+
+func (e *InvalidInputError) Error() string {
+	if e.Field != "" {
+		return e.Field + ": " + e.Message
+	}
+	return e.Message
+}
+
+func (e *InvalidInputError) Unwrap() error { return e.Cause }

--- a/internal/handler/errors.go
+++ b/internal/handler/errors.go
@@ -145,6 +145,22 @@ func WriteError(w http.ResponseWriter, err error) {
 		})
 		return
 	}
+	// Validation errors: services return *domain.InvalidInputError when user
+	// input fails a domain rule (empty name, future birthday, malformed email).
+	// These are safe to surface verbatim — services construct them with
+	// human-readable, field-scoped wording. Without this branch, validation
+	// errors fall through to the generic 500 path and the user gets
+	// "an internal error occurred" instead of "birthday: must be in the past".
+	var invErr *domain.InvalidInputError
+	if errors.As(err, &invErr) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ErrorResponse{
+			Error:   "invalid_input",
+			Message: invErr.Error(),
+		})
+		return
+	}
 
 	status, known := MapServiceError(err)
 	var message string

--- a/internal/handler/errors_test.go
+++ b/internal/handler/errors_test.go
@@ -311,3 +311,55 @@ func TestCommonHTTPErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestWriteError_MapsInvalidInputErrorTo400 verifies the new validation
+// branch added for v1.3.0 manual-test-plan bug B: a *domain.InvalidInputError
+// from a service must surface as HTTP 400 with the message + "invalid_input"
+// code, not as the generic "an internal error occurred" 500 the user saw.
+func TestWriteError_MapsInvalidInputErrorTo400(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteError(w, &domain.InvalidInputError{Field: "birthday", Message: "must be in the past"})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error != "invalid_input" {
+		t.Errorf("Error = %q, want %q", resp.Error, "invalid_input")
+	}
+	if resp.Message != "birthday: must be in the past" {
+		t.Errorf("Message = %q, want %q", resp.Message, "birthday: must be in the past")
+	}
+}
+
+// TestWriteError_MapsInvalidInputError_WithoutField verifies that an
+// InvalidInputError with no Field set surfaces just the Message.
+func TestWriteError_MapsInvalidInputError_WithoutField(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteError(w, &domain.InvalidInputError{Message: "input is malformed"})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var resp ErrorResponse
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Message != "input is malformed" {
+		t.Errorf("Message = %q, want %q", resp.Message, "input is malformed")
+	}
+}
+
+// TestWriteError_MapsWrappedInvalidInputErrorTo400 confirms errors.As reaches
+// the typed value through fmt.Errorf wrapping.
+func TestWriteError_MapsWrappedInvalidInputErrorTo400(t *testing.T) {
+	inner := &domain.InvalidInputError{Field: "email", Message: "not parseable"}
+	wrapped := errors.Join(errors.New("controller context"), inner)
+	w := httptest.NewRecorder()
+	WriteError(w, wrapped)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d (wrapped InvalidInputError)", w.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/service/admin_user_service.go
+++ b/internal/service/admin_user_service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"errors"
 	"fmt"
 	"net/mail"
 	"strings"
@@ -161,7 +160,7 @@ func (s *AdminUserService) UpdateProfile(
 	if fields.Name != nil {
 		name := strings.TrimSpace(*fields.Name)
 		if name == "" || len(name) > 100 {
-			return nil, errors.New("name length must be 1–100 characters")
+			return nil, &domain.InvalidInputError{Field: "name", Message: "must be 1–100 characters"}
 		}
 		user.Name = name
 	}
@@ -169,7 +168,7 @@ func (s *AdminUserService) UpdateProfile(
 	if fields.Email != nil {
 		addr, parseErr := mail.ParseAddress(*fields.Email)
 		if parseErr != nil {
-			return nil, fmt.Errorf("invalid email: %w", parseErr)
+			return nil, &domain.InvalidInputError{Field: "email", Message: "is not a valid address", Cause: parseErr}
 		}
 		if addr.Address != user.Email {
 			user.Email = addr.Address
@@ -181,7 +180,7 @@ func (s *AdminUserService) UpdateProfile(
 
 	if fields.Birthday != nil {
 		if fields.Birthday.After(time.Now()) {
-			return nil, errors.New("birthday must be in the past")
+			return nil, &domain.InvalidInputError{Field: "birthday", Message: "must be in the past"}
 		}
 		user.Birthday = fields.Birthday
 	}

--- a/internal/service/admin_user_service_test.go
+++ b/internal/service/admin_user_service_test.go
@@ -885,3 +885,50 @@ func (r *getByIDErrorOnSecondCallRepo) CountWithFilter(filter domain.UserListFil
 // ---------------------------------------------------------------------------
 
 func strPtr(s string) *string { return &s }
+
+// TestAdminUserService_UpdateProfile_ValidationErrorsAreTyped guards the
+// contract that validation failures return *domain.InvalidInputError so the
+// HTTP layer can surface them as 400 with a helpful message rather than the
+// generic 500 path. Test 12 in the v1.3.0 manual-test plan caught this — a
+// future-dated birthday returned a plain `errors.New(...)` that fell through
+// to `WriteError`'s "an internal error occurred" branch.
+func TestAdminUserService_UpdateProfile_ValidationErrorsAreTyped(t *testing.T) {
+	user := makeNormalUser(20, "validator@example.com", "Vera")
+	emptyName := ""
+	tooLong := strings.Repeat("x", 101)
+	badEmail := "not-an-email"
+	future := time.Now().Add(24 * time.Hour)
+
+	cases := []struct {
+		name      string
+		fields    ProfileUpdateFields
+		wantField string
+	}{
+		{"empty name", ProfileUpdateFields{Name: &emptyName}, "name"},
+		{"name over 100 chars", ProfileUpdateFields{Name: &tooLong}, "name"},
+		{"unparseable email", ProfileUpdateFields{Email: &badEmail}, "email"},
+		{"future birthday", ProfileUpdateFields{Birthday: &future}, "birthday"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newStubUserRepo()
+			repo.addUser(user)
+			svc := newService(repo, &stubRefreshTokenRepo{}, &stubEmailSvc{}, &stubAuditLogger{})
+
+			_, err := svc.UpdateProfile(1, 20, tc.fields, user.UpdatedAt)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			var invErr *domain.InvalidInputError
+			if !errors.As(err, &invErr) {
+				t.Fatalf("expected *domain.InvalidInputError, got %T: %v", err, err)
+			}
+			if invErr.Field != tc.wantField {
+				t.Errorf("Field = %q, want %q", invErr.Field, tc.wantField)
+			}
+			if invErr.Message == "" {
+				t.Error("Message must be non-empty so the user knows what went wrong")
+			}
+		})
+	}
+}

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -61,6 +62,13 @@ const (
 	SendTimeout       = 30 * time.Second
 	OverallTimeout    = 60 * time.Second
 )
+
+// errEmailDisabled is the error returned by debug/test send methods when the
+// email Service is nil (EMAIL_ENABLED=false at startup). Production Send*
+// methods that return error use the nil-receiver guard to return nil silently;
+// the debug/test path needs an explicit error so admins running diagnostics
+// see why the operation was a no-op.
+var errEmailDisabled = errors.New("email service is disabled (set EMAIL_ENABLED=true and configure SMTP_HOST to enable)")
 
 // SMTPDebugInfo captures detailed SMTP conversation info for debugging
 type SMTPDebugInfo struct {
@@ -125,8 +133,20 @@ func extractEmailAddress(addr string) string {
 	return strings.TrimSpace(addr)
 }
 
-// Send sends an email message
+// Send sends an email message.
+//
+// Nil-receiver behavior: if email is disabled at startup
+// (cmd/actalog/main.go:316 sets emailService = nil when EMAIL_ENABLED is
+// false or SMTP_HOST is empty), every Send* method on this type would
+// otherwise panic on the first s.logger.Printf because s.logger is unreachable
+// through a nil pointer. We guard with `s == nil` at the top of each Send*
+// method and return nil silently — the disabled state is intentional and
+// already announced at startup. Callers see "send succeeded with no-op" which
+// matches the documented "emails will not be sent" behavior.
 func (s *Service) Send(msg Message) error {
+	if s == nil {
+		return nil
+	}
 	s.logger.Printf("[INFO] Attempting to send email to %v, subject: %s", msg.To, msg.Subject)
 
 	// Extract the actual email address from FromAddress (removes display name if present)
@@ -267,6 +287,9 @@ func (s *Service) sendWithTLS(addr string, auth smtp.Auth, fromEmail string, to 
 
 // SendPasswordResetEmail sends a password reset email
 func (s *Service) SendPasswordResetEmail(to, resetURL string) error {
+	if s == nil {
+		return nil
+	}
 	s.logger.Printf("[INFO] Preparing password reset email for %s with URL: %s", to, resetURL)
 	subject := "ActaLog - Password Reset Request"
 
@@ -318,6 +341,9 @@ func (s *Service) SendPasswordResetEmail(to, resetURL string) error {
 
 // SendVerificationEmail sends an email verification email
 func (s *Service) SendVerificationEmail(to, verifyURL string) error {
+	if s == nil {
+		return nil
+	}
 	s.logger.Printf("[INFO] Preparing verification email for %s with URL: %s", to, verifyURL)
 	subject := "ActaLog - Verify Your Email Address"
 
@@ -369,6 +395,9 @@ func (s *Service) SendVerificationEmail(to, verifyURL string) error {
 
 // SendHTMLEmail sends a generic HTML email
 func (s *Service) SendHTMLEmail(to, subject, htmlBody string) error {
+	if s == nil {
+		return nil
+	}
 	s.logger.Printf("[INFO] Preparing HTML email for %s with subject: %s", to, subject)
 
 	return s.Send(Message{
@@ -381,6 +410,9 @@ func (s *Service) SendHTMLEmail(to, subject, htmlBody string) error {
 
 // SendWelcomeEmail sends a welcome email to a new user
 func (s *Service) SendWelcomeEmail(to, userName, appURL string) error {
+	if s == nil {
+		return nil
+	}
 	s.logger.Printf("[INFO] Preparing welcome email for %s", to)
 	subject := "Welcome to ActaLog - Let's Get Started!"
 
@@ -477,6 +509,9 @@ func (s *Service) GetConfig() EmailConfigInfo {
 
 // SendWithDebug sends an email message and captures detailed debug information
 func (s *Service) SendWithDebug(msg Message) SendResult {
+	if s == nil {
+		return SendResult{Success: false, Error: errEmailDisabled}
+	}
 	debug := &SMTPDebugInfo{
 		StartTime:      time.Now(),
 		ConnectionHost: s.config.SMTPHost,
@@ -779,6 +814,9 @@ func (s *Service) sendWithSTARTTLSDebug(addr string, fromEmail string, to []stri
 
 // SendTestEmail sends a test email with system information
 func (s *Service) SendTestEmail(to string) SendResult {
+	if s == nil {
+		return SendResult{Success: false, Error: errEmailDisabled}
+	}
 	s.logger.Printf("[INFO] Preparing test email for %s", to)
 
 	tlsMode := "STARTTLS"

--- a/pkg/email/email_test.go
+++ b/pkg/email/email_test.go
@@ -1584,3 +1584,76 @@ func TestService_SendHTMLEmail_ComplexHTML(t *testing.T) {
 		t.Error("Should log HTML email preparation")
 	}
 }
+
+// TestNilReceiver_NoPanic_ProductionSendMethods verifies that every production
+// Send* method that returns error is safe to call on a nil *Service. This
+// matches the runtime situation when EMAIL_ENABLED=false at startup (see
+// cmd/actalog/main.go:316 — emailService is nil in that case). Before the
+// nil-guard fix, a nil receiver caused panics on `s.logger.Printf(...)` at
+// the top of each method, crashing /api/auth/forgot-password and the admin
+// email-change flow with HTTP 500.
+func TestNilReceiver_NoPanic_ProductionSendMethods(t *testing.T) {
+	var s *Service // nil — exactly what main.go passes when email is disabled
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"Send", func() error { return s.Send(Message{To: []string{"a@b"}, Subject: "x", Body: "y"}) }},
+		{"SendPasswordResetEmail", func() error { return s.SendPasswordResetEmail("a@b", "https://x") }},
+		{"SendVerificationEmail", func() error { return s.SendVerificationEmail("a@b", "https://x") }},
+		{"SendHTMLEmail", func() error { return s.SendHTMLEmail("a@b", "subj", "<p>body</p>") }},
+		{"SendWelcomeEmail", func() error { return s.SendWelcomeEmail("a@b", "User", "https://x") }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("nil-receiver call panicked: %v", r)
+				}
+			}()
+			if err := tc.call(); err != nil {
+				t.Errorf("nil-receiver call returned error %v; expected nil (silent no-op)", err)
+			}
+		})
+	}
+}
+
+// TestNilReceiver_DebugMethods_ReturnDisabledError verifies that debug/test
+// send methods return SendResult{Success:false, Error:errEmailDisabled} when
+// invoked on a nil receiver. These methods are admin-only diagnostics — silent
+// no-op would mask the disabled state, so they explicitly surface it.
+func TestNilReceiver_DebugMethods_ReturnDisabledError(t *testing.T) {
+	var s *Service
+
+	t.Run("SendWithDebug", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("SendWithDebug panicked on nil receiver: %v", r)
+			}
+		}()
+		res := s.SendWithDebug(Message{To: []string{"a@b"}, Subject: "x", Body: "y"})
+		if res.Success {
+			t.Error("expected Success=false on nil receiver")
+		}
+		if res.Error == nil {
+			t.Error("expected non-nil Error on nil receiver")
+		}
+	})
+
+	t.Run("SendTestEmail", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("SendTestEmail panicked on nil receiver: %v", r)
+			}
+		}()
+		res := s.SendTestEmail("a@b")
+		if res.Success {
+			t.Error("expected Success=false on nil receiver")
+		}
+		if res.Error == nil {
+			t.Error("expected non-nil Error on nil receiver")
+		}
+	})
+}


### PR DESCRIPTION
Two backend bugs caught during v1.3.0 manual smoke testing.

## Bugs

**A) Nil-receiver panic when email is disabled** — every \`*email.Service\` Send method called \`s.logger.Printf\` as its first line. When \`EMAIL_ENABLED=false\` (no SMTP config), \`emailService\` is nil, so any send path panicked. Triggered \`/api/auth/forgot-password\` 500s (public endpoint!) and admin email-change 500s. The admin path also caused a downstream OCC cascade: row was written before the panic, client never got the new \`updated_at\`, next save 409'd.

**B) Validation errors leaked through as opaque 500** — \`admin_user_service.go\` used \`errors.New(\"birthday must be in the past\")\`. \`WriteError\` didn't recognize the type and fell through to the 500 \"an internal error occurred\" branch. User had no way to know what was wrong.

## Fix

A: nil-receiver guards on every public \`Send*\` method on \`*email.Service\`. Production senders return nil silently; debug senders return a typed \`errEmailDisabled\`.

B: new \`domain.InvalidInputError\` type. Service validation sites use it; \`WriteError\` gains an \`errors.As\` branch that surfaces 400 with body \`{error: \"invalid_input\", message: \"field: rule\"}\`.

## Verified

- Full Go test suite green (10 new tests across pkg/email, internal/service, internal/handler).
- Docker SQLite smoke: forgot-password → 200 (was panic), admin email change → 200 (was 500), future birthday → 400 \"birthday: must be in the past\" (was 500 \"internal error\"), empty name → 400, malformed email → 400.

## Test plan

- [ ] CI matrix green on rebase
- [ ] Confirm \`/api/auth/forgot-password\` returns 200 with email disabled
- [ ] Confirm admin email change persists \`updated_at\` and returns 200
- [ ] Confirm validation errors carry a useful message and 400 status

🤖 Generated with [Claude Code](https://claude.com/claude-code)