### PR TITLE
release: v1.3.3 — maintenance (deps, toolchain, CI npm pin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,14 @@ jobs:
         with:
           node-version: '24'
 
+      # Pin npm to the version that generated web/package-lock.json.
+      # setup-node's bundled npm floats with the node 24.x patch release, and a
+      # newer npm resolves the rolldown wasm-fallback @emnapi optional deps into
+      # a different lockfile shape, breaking `npm ci`. Keep this in lockstep with
+      # the "packageManager" field in web/package.json.
+      - name: Pin npm to lockfile version
+        run: npm i -g npm@11.16.0
+
       - name: Cache node modules
         uses: actions/cache@v6
         with:
@@ -168,6 +176,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+
+      # Pin npm to the version that generated web/package-lock.json.
+      # setup-node's bundled npm floats with the node 24.x patch release, and a
+      # newer npm resolves the rolldown wasm-fallback @emnapi optional deps into
+      # a different lockfile shape, breaking `npm ci`. Keep this in lockstep with
+      # the "packageManager" field in web/package.json.
+      - name: Pin npm to lockfile version
+        run: npm i -g npm@11.16.0
 
       - name: Cache node modules
         uses: actions/cache@v6

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A mobile-first fitness tracker for CrossFit enthusiasts to log workouts, track progress, and analyze performance.
 
-[![Version](https://img.shields.io/badge/version-1.3.2-blue)](https://github.com/johnzastrow/actalog/blob/main/docs/CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.3.3-blue)](https://github.com/johnzastrow/actalog/blob/main/docs/CHANGELOG.md)
 [![Docker Image](https://img.shields.io/badge/Docker-ghcr.io%2Fjohnzastrow%2Factalog-2496ED?style=flat&logo=docker)](https://github.com/johnzastrow/actalog/pkgs/container/actalog)
 [![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://golang.org)
 [![Vue.js](https://img.shields.io/badge/Vue.js-3.x-4FC08D?style=flat&logo=vue.js)](https://vuejs.org)
@@ -44,7 +44,7 @@ docker pull ghcr.io/johnzastrow/actalog:latest
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable build |
-| `v1.3.2` | Current versioned release |
+| `v1.3.3` | Current versioned release |
 | `dev` | Development build |
 
 **Run with SQLite (simplest):**
@@ -205,6 +205,7 @@ Most endpoints require JWT authentication. To use protected endpoints in Swagger
 
 - v1.3.0 introduces the admin user-edit screen with a four-layer defense for system-protected accounts. See `docs/security/PROTECTED_USERS.md`.
 - v1.3.2 adds admin-side user creation, admin-set-password, and an operator break-glass CLI (`actalog admin force-edit-protected`) for protected-user recovery. See `docs/security/PROTECTED_USERS.md` §9.
+- v1.3.3 is a maintenance release refreshing security-relevant dependencies (`golang.org/x/crypto`, `dompurify`) and hardening the CI toolchain. See `docs/CHANGELOG.md`.
 
 ## License
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,12 @@ WORKDIR /app/web
 # Copy package files
 COPY web/package.json web/package-lock.json ./
 
+# Pin npm to the version that generated package-lock.json. The node:24-alpine
+# base image's bundled npm floats across rebuilds; a newer npm reshapes the
+# rolldown wasm-fallback @emnapi optional deps and breaks `npm ci`. Keep this in
+# lockstep with the "packageManager" field in web/package.json.
+RUN npm i -g npm@11.16.0
+
 # Install dependencies (including dev dependencies needed for build)
 RUN npm ci
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to ActaLog will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-07-04 — Maintenance: dependency & toolchain updates
+
+Maintenance release. No application behavior changes — dependency, toolchain, and
+CI hardening only. All 23 changes since v1.3.2 are dependency or build-tooling
+bumps.
+
+### Changed — Backend (Go) dependencies
+- `golang.org/x/crypto` 0.50.0 → 0.53.0
+- `github.com/mattn/go-sqlite3` 1.14.42 → 1.14.47
+- `github.com/jackc/pgx/v5` 5.9.2 → 5.10.0
+- `github.com/go-chi/chi/v5` 5.2.5 → 5.3.0
+- `github.com/go-sql-driver/mysql` 1.9.3 → 1.10.0
+
+### Changed — Frontend (web) dependencies
+- `vite` 7.3.1 → 8.0.11
+- `vuetify` (bump)
+- `axios` 1.13.5 → 1.18.1
+- `marked` 17.0.6 → 18.0.5
+- `jsdom` 28.1.0 → 29.1.1
+- `dompurify` 3.3.3 → 3.4.2
+- `sharp` (bump)
+- `eslint` 9.39.2 → 10.6.0, `prettier` 3.8.3 → 3.9.3 (dev)
+
+### Changed — Toolchain & CI
+- Upgraded the web build to **Node 24** and pinned the npm toolchain (`packageManager: npm@11.16.0`)
+- Bumped GitHub Actions: `actions/checkout` 6→7, `actions/cache` 5→6, `actions/upload-pages-artifact` 4→5, `actions/github-script` 8→9, `docker/build-push-action` 6→7, `golangci/golangci-lint-action` 6→9
+
+### Fixed — CI lockfile stability
+- Pinned npm to **11.16.0** in CI (`ci.yml`) and the Docker frontend build stage so it matches the version that generates `web/package-lock.json`. `setup-node`'s bundled npm floats with the Node 24.x patch line, and a newer npm reshapes the rolldown wasm-fallback `@emnapi` optional deps, which was breaking `npm ci` on dependency-update PRs.
+
 ## [1.3.2] - 2026-05-07 — Admin user lifecycle + protected-user break-glass CLI
 
 ### Added — Operator break-glass CLI

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,11 +9,11 @@ const (
 	// Minor version number
 	Minor = 3
 	// Patch version number
-	Patch = 2
+	Patch = 3
 	// PreRelease identifier (e.g., "alpha", "beta", "rc1")
 	PreRelease = ""
 	// Build number - increment this with each code change
-	Build = 56
+	Build = 57
 )
 
 // Version returns the full semantic version string

--- a/web/package.json
+++ b/web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "actalog-web",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "ActaLog - CrossFit Workout Tracker",
   "private": true,
   "type": "module",
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "npm@11.6.1",
+  "packageManager": "npm@11.16.0",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Release v1.3.3 — Maintenance

Dependency- and toolchain-only maintenance release. **No application behavior changes.** Consolidates the 23 dependency/toolchain bumps merged since v1.3.2 and cuts the release.

### Version
- \`pkg/version/version.go\`: Patch 2 → 3, Build 56 → 57
- \`web/package.json\`: 1.3.2 → 1.3.3
- README version badge + release table

### CI hardening (fixes the root cause of the recent failed dependency PRs)
- Pin npm to **11.16.0** in \`ci.yml\` (web build/test) and the Docker frontend stage, matching the npm that generates \`web/package-lock.json\`. \`setup-node\`'s bundled npm floats with the Node 24.x patch line; a newer npm reshapes the rolldown wasm-fallback \`@emnapi\` optional deps and breaks \`npm ci\`.
- \`packageManager\` pinned to \`npm@11.16.0\`.

### Docs
- \`docs/CHANGELOG.md\`: dated \`[1.3.3]\` entry summarizing all dependency/toolchain changes.

Verified locally: \`go build\` OK, version reports \`1.3.3+build.57\`, web build OK, 1274/1274 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)