### PR TITLE
test(e2e): reusable Playwright e2e + visual suite

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.auth/
+screenshots/
+test-results/
+playwright-report/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,73 @@
+# ActaLog end-to-end tests (Playwright)
+
+Reusable browser tests that drive a running ActaLog deployment: they verify the
+login/register pages, sign in, walk the main authenticated screens, and capture a
+screenshot of every screen (desktop + mobile) for visual review.
+
+They are **self-contained** — this folder has its own `package.json`, so it does
+not touch `web/`'s dependencies or lockfile.
+
+## Why these exist
+
+A dependency sweep once upgraded Vuetify across a major version (3 -> 4) without
+migrating the app, which silently broke component styling (outlined inputs,
+cards, spacing) app-wide. The build still passed CI. `auth.spec.js` now has an
+explicit guard (the login field must render a real outlined border), and
+`navigation.spec.js` screenshots every screen so this class of regression is
+visible before shipping.
+
+## Setup
+
+```bash
+cd e2e
+npm install
+npm run install-browsers   # one-time: installs the Chromium Playwright build
+```
+
+## Run
+
+Target is chosen with `BASE_URL` (defaults to `http://localhost:8095`, a local
+container).
+
+```bash
+# Against a local container (see below)
+npm test
+
+# Against beta
+BASE_URL=https://albeta.fluidgrid.site npm test
+
+# Against production — never auto-register; supply a real, disposable account
+BASE_URL=https://al.fluidgrid.site \
+  E2E_REGISTER=false E2E_EMAIL='you@example.com' E2E_PASSWORD='...' \
+  npm test
+
+npm run report   # open the HTML report
+```
+
+Screenshots land in `screenshots/` (git-ignored): `login.png`, `register.png`,
+and `<project>/<screen>.png` for each authenticated screen.
+
+### Spin up a local container to test a specific image
+
+```bash
+docker run -d --name actalog-local-test -p 8095:8080 \
+  -e APP_ENV=development -e JWT_SECRET=local-test-secret \
+  ghcr.io/johnzastrow/actalog:v1.3.0
+```
+
+## Environment variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `BASE_URL` | `http://localhost:8095` | Deployment under test |
+| `E2E_EMAIL` | `e2e-admin@actalog.local` | Test account email |
+| `E2E_PASSWORD` | `TestPass123!` | Test account password |
+| `E2E_REGISTER` | `true` | If `false`, never register — log in only (use for prod) |
+
+## Layout
+
+- `playwright.config.js` — projects: `anon-desktop`, `authed-desktop`, `authed-mobile`
+- `global-setup.js` — registers-or-logs-in once, saves `.auth/admin.json`
+- `fixtures.js` — auto console-error collector (benign CSP/font noise filtered)
+- `tests/auth.spec.js` — login/register rendering + outlined-input regression guard
+- `tests/navigation.spec.js` — authenticated screens + full-page screenshots

--- a/e2e/fixtures.js
+++ b/e2e/fixtures.js
@@ -1,0 +1,37 @@
+import { test as base, expect } from '@playwright/test';
+
+// Console errors that are known-benign and must not fail a test:
+//  - the redundant jsdelivr @mdi/font <link> blocked by CSP (icons are bundled
+//    locally, so this is cosmetic — tracked for cleanup, not a real failure).
+const BENIGN_CONSOLE = [
+  /cdn\.jsdelivr\.net/i,
+  /Content Security Policy/i,
+  /favicon/i,
+];
+
+// `test` extends the base with an automatic console-error collector. Any page
+// error or console.error that is not in the benign list is attached to the test
+// and can be asserted with `expectNoConsoleErrors`.
+export const test = base.extend({
+  consoleErrors: [
+    async ({ page }, use) => {
+      const errors = [];
+      page.on('console', (msg) => {
+        if (msg.type() !== 'error') return;
+        const text = msg.text();
+        if (BENIGN_CONSOLE.some((re) => re.test(text))) return;
+        errors.push(text);
+      });
+      page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+      await use(errors);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };
+
+// Assert no unexpected console/page errors accumulated so far.
+export function expectNoConsoleErrors(errors) {
+  expect(errors, `unexpected console errors:\n${errors.join('\n')}`).toHaveLength(0);
+}

--- a/e2e/global-setup.js
+++ b/e2e/global-setup.js
@@ -1,0 +1,89 @@
+import { chromium } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { mkdirSync, existsSync } from 'node:fs';
+
+// Creates (or reuses) an authenticated session and saves it to .auth/admin.json
+// for the authenticated projects. Idempotent: logs in if the account already
+// exists, otherwise registers it first (registration auto-authenticates and the
+// first user becomes admin).
+//
+// Env:
+//   BASE_URL       target under test (default http://localhost:8095)
+//   E2E_EMAIL      test account email    (default e2e-admin@actalog.local)
+//   E2E_PASSWORD   test account password (default TestPass123!)
+//   E2E_REGISTER   set to "false" to never register (use for prod: supply real creds)
+export default async function globalSetup() {
+  // Skip all auth setup — for running the anonymous render specs against a real
+  // deployment (beta/prod) without creating accounts or spending rate-limit budget.
+  if (process.env.E2E_SKIP_AUTH === '1') return;
+
+  const BASE = process.env.BASE_URL || 'http://localhost:8095';
+  const EMAIL = process.env.E2E_EMAIL || 'e2e-admin@actalog.local';
+  const PASS = process.env.E2E_PASSWORD || 'TestPass123!';
+  const allowRegister = process.env.E2E_REGISTER !== 'false';
+
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const authDir = join(dir, '.auth');
+  const statePath = join(authDir, 'admin.json');
+  mkdirSync(authDir, { recursive: true });
+
+  const browser = await chromium.launch();
+
+  // The auth endpoints are rate-limited (5 requests / 15 min / IP). Reuse a
+  // still-valid saved session so re-runs cost zero auth calls. Set E2E_FRESH_AUTH=1
+  // to force a new login.
+  if (existsSync(statePath) && process.env.E2E_FRESH_AUTH !== '1') {
+    const ctx = await browser.newContext({ storageState: statePath });
+    const page = await ctx.newPage();
+    await page.goto(`${BASE}/dashboard`, { waitUntil: 'networkidle' }).catch(() => {});
+    if (page.url().includes('/dashboard')) {
+      await browser.close();
+      return; // existing session still valid
+    }
+    await ctx.close();
+  }
+
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+
+  async function login() {
+    await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' });
+    await page.getByLabel('Email').fill(EMAIL);
+    await page.getByLabel('Password', { exact: true }).fill(PASS);
+    await page.getByRole('button', { name: /sign in/i }).click();
+    try {
+      await page.waitForURL('**/dashboard', { timeout: 10_000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  let ok = await login();
+  if (!ok && allowRegister) {
+    await page.goto(`${BASE}/register`, { waitUntil: 'networkidle' });
+    await page.getByLabel('Name').fill('E2E Admin');
+    await page.getByLabel('Email').fill(EMAIL);
+    await page.getByLabel('Password', { exact: true }).fill(PASS);
+    await page.getByLabel('Confirm Password', { exact: true }).fill(PASS);
+    await page.getByRole('button', { name: /sign up|register|create account/i }).click();
+    // Register auto-authenticates AND shows an email hint; reset client state so
+    // we get a clean, deterministic logged-in session via the login form.
+    await page.waitForTimeout(1500);
+    await ctx.clearCookies();
+    await page.evaluate(() => { localStorage.clear(); sessionStorage.clear(); }).catch(() => {});
+    ok = await login();
+  }
+
+  if (!ok) {
+    await browser.close();
+    throw new Error(
+      `Could not authenticate against ${BASE} as ${EMAIL}. ` +
+        `Set E2E_EMAIL/E2E_PASSWORD to a valid account (and E2E_REGISTER=false for prod).`
+    );
+  }
+
+  await ctx.storageState({ path: join(authDir, 'admin.json') });
+  await browser.close();
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "actalog-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "actalog-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.58.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "actalog-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Reusable Playwright end-to-end / visual-regression tests for ActaLog. Target any deployment via BASE_URL.",
+  "type": "module",
+  "scripts": {
+    "install-browsers": "playwright install chromium",
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.0"
+  }
+}

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Target is controlled by BASE_URL so the same suite runs against a local
+// container, the beta host, or production. Defaults to the local test container.
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8095';
+
+export default defineConfig({
+  testDir: './tests',
+  // Auth state is created once (register-or-login) and reused by authed specs.
+  globalSetup: './global-setup.js',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  timeout: 45_000,
+  expect: { timeout: 10_000 },
+  outputDir: 'test-results',
+  use: {
+    baseURL: BASE_URL,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'off',
+  },
+  projects: [
+    // Anonymous (logged-out) flows: login/register rendering + the Vuetify regression guard.
+    {
+      name: 'anon-desktop',
+      testMatch: /auth\.spec\.js/,
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 900 } },
+    },
+    // Authenticated navigation + visual screenshots, desktop and mobile (mobile-first PWA).
+    {
+      name: 'authed-desktop',
+      testMatch: /navigation\.spec\.js/,
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 900 },
+        storageState: '.auth/admin.json',
+      },
+    },
+    {
+      name: 'authed-mobile',
+      testMatch: /navigation\.spec\.js/,
+      use: { ...devices['Pixel 5'], storageState: '.auth/admin.json' },
+    },
+  ],
+});

--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -1,0 +1,56 @@
+import { test, expect, expectNoConsoleErrors } from '../fixtures.js';
+
+const EMAIL = process.env.E2E_EMAIL || 'e2e-admin@actalog.local';
+const PASS = process.env.E2E_PASSWORD || 'TestPass123!';
+
+test.describe('unauthenticated pages', () => {
+  test('login page renders with outlined (styled) inputs', async ({ page, consoleErrors }) => {
+    await page.goto('/login', { waitUntil: 'networkidle' });
+
+    await expect(page.getByText('ActaLog')).toBeVisible();
+    await expect(page.getByText(/sign in to your account/i)).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+
+    // Regression guard for the Vuetify 3->4 breakage. The inputs use the "solo"
+    // variant, which renders a filled, elevated box (solid background + shadow).
+    // Under the broken v4 build these fields collapsed to flat, transparent,
+    // full-width rows. Assert the visual properties rather than a class name so
+    // the guard is resilient across Vuetify versions.
+    await expect(page.getByLabel('Email')).toBeVisible();
+    const style = await page.getByLabel('Email').evaluate((input) => {
+      const field = input.closest('.v-field');
+      if (!field) return null;
+      const cs = getComputedStyle(field);
+      return { cls: field.className, bg: cs.backgroundColor, shadow: cs.boxShadow, height: field.getBoundingClientRect().height };
+    });
+    expect(style, 'email input must be wrapped in a .v-field').not.toBeNull();
+    expect(style.height, 'input field height').toBeGreaterThan(20);
+    // The solo variant renders an elevation shadow; the broken v4 render lost it.
+    expect(style.shadow, 'input field must have an elevation shadow').not.toBe('none');
+    expect(style.shadow.length, 'input field must have an elevation shadow').toBeGreaterThan(10);
+
+    await page.screenshot({ path: 'screenshots/login.png' });
+    expectNoConsoleErrors(consoleErrors);
+  });
+
+  test('login succeeds and lands on the dashboard', async ({ page }) => {
+    await page.goto('/login', { waitUntil: 'networkidle' });
+    await page.getByLabel('Email').fill(EMAIL);
+    await page.getByLabel('Password', { exact: true }).fill(PASS);
+    await page.getByRole('button', { name: /sign in/i }).click();
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
+  });
+
+  test('register page renders all fields', async ({ page, consoleErrors }) => {
+    await page.goto('/register', { waitUntil: 'networkidle' });
+    await expect(page.getByLabel('Name')).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Confirm Password', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign up|register|create account/i })).toBeVisible();
+    await page.screenshot({ path: 'screenshots/register.png' });
+    expectNoConsoleErrors(consoleErrors);
+  });
+});

--- a/e2e/tests/navigation.spec.js
+++ b/e2e/tests/navigation.spec.js
@@ -1,0 +1,38 @@
+import { test, expect, expectNoConsoleErrors } from '../fixtures.js';
+
+// Main authenticated routes. Screenshotting each catches broad visual/layout
+// regressions (e.g. a UI-framework upgrade dropping component styles) across the
+// app, not just the login page.
+const ROUTES = [
+  ['dashboard', '/dashboard'],
+  ['workouts', '/workouts'],
+  ['calendar', '/workouts/calendar'],
+  ['movements', '/movements'],
+  ['wods', '/wods'],
+  ['performance', '/performance'],
+  ['prs', '/prs'],
+  ['leaderboard', '/leaderboard'],
+  ['notifications', '/notifications'],
+  ['profile', '/profile'],
+  ['settings', '/settings'],
+  ['admin', '/admin'],
+];
+
+test.describe('authenticated navigation', () => {
+  for (const [name, path] of ROUTES) {
+    test(`renders ${name}`, async ({ page, consoleErrors }, testInfo) => {
+      const resp = await page.goto(path, { waitUntil: 'networkidle' });
+
+      // Auth must hold — a bounce back to /login means the session broke.
+      expect(page.url(), `expected to stay on ${path}, not redirect to login`).not.toContain('/login');
+      // The Vuetify app root should be present and the page should not be a hard error.
+      await expect(page.locator('.v-application')).toBeVisible();
+      if (resp) expect(resp.status(), `HTTP status for ${path}`).toBeLessThan(400);
+
+      const shot = `screenshots/${testInfo.project.name}/${name}.png`;
+      await page.screenshot({ path: shot, fullPage: true });
+
+      expectNoConsoleErrors(consoleErrors);
+    });
+  }
+});


### PR DESCRIPTION
## What

Adds a self-contained Playwright end-to-end / visual-regression suite under `e2e/`.

- Own `package.json` — does **not** touch `web/`'s dependencies or lockfile.
- Parameterized by `BASE_URL` (local container / beta / prod) and env-configurable creds.

## Specs

- **`auth.spec.js`** — login & register rendering, login flow, and a **regression guard** asserting the input field keeps its Vuetify elevation. This guards the class of bug where a Vuetify 3→4 bump silently flattened the whole UI while the build still passed CI.
- **`navigation.spec.js`** — 12 authenticated screens × **desktop + mobile**, screenshotting each for visual review.
- **`global-setup.js`** — register-or-login with session reuse (auth endpoints are rate-limited 5/15min/IP). `E2E_SKIP_AUTH=1` runs the anonymous render checks against a real deployment without creating accounts.

## Verified

- 27/27 green against the `v1.3.0` and `v1.2.2` images (run locally).
- Render + regression-guard green against live beta.

## Notes

`screenshots/`, `.auth/`, `test-results/`, `node_modules/` are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)