### PR TITLE
Vuetify 4 UI polish: readability & spacing — v1.3.6

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to ActaLog will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.6] - 2026-07-19 — Vuetify 4 UI polish (readability & spacing)
+
+Follow-up readability/spacing fixes on the v1.3.5 Vuetify 4 build, all found while
+testing on beta. All are global (theme-token based) so they apply everywhere.
+
+### Fixed
+- **Entry-field text was too small to read while typing.** Vuetify 4 renders the
+  actual `.v-field__input` at ~14px (smaller under `density="compact"`, of which
+  the app has 342 across 54 files); setting font-size on `.v-field` never reached
+  the input. Pinned `.v-field .v-field__input` to 16px (also avoids iOS tap-zoom).
+- **Low-emphasis text was too light to read.** `text-medium-emphasis` rendered at
+  0.6 alpha (~#6b6b6b); darkened to 0.82 app-wide.
+- **Card count chips were nearly invisible.** `<v-chip color="#e0e0e0">` sets the
+  *text* to near-white under v4's tonal variant; replaced with `variant="tonal"`
+  (readable on-surface text) in WorkoutsView, WODsView, WorkoutTimelineView.
+- **Text buttons had no horizontal padding.** Labels sat flush to the button
+  edges; restored Vuetify's per-size inline padding (icon buttons stay square).
+- **Tooltips were cramped;** bumped padding from 5px/16px to 8px/14px.
+
 ## [1.3.5] - 2026-07-19 — Vuetify 4 migration completed + UI refresh
 
 Completes the Vuetify 3 → 4 migration that v1.3.3's dependency sweep began but

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,11 +9,11 @@ const (
 	// Minor version number
 	Minor = 3
 	// Patch version number
-	Patch = 5
+	Patch = 6
 	// PreRelease identifier (e.g., "alpha", "beta", "rc1")
 	PreRelease = ""
 	// Build number - increment this with each code change
-	Build = 59
+	Build = 60
 )
 
 // Version returns the full semantic version string

--- a/web/src/assets/redesign-plus.css
+++ b/web/src/assets/redesign-plus.css
@@ -84,6 +84,23 @@
   -webkit-text-stroke: 0.5px currentColor;
 }
 
+/* Low-emphasis text was too light to read: Vuetify renders `text-medium-emphasis`
+   at 0.6 alpha (~#6b6b6b on white) — borderline for captions/hints and the lowest
+   line on cards. The theme sets --v-medium-emphasis-opacity on a node we can't
+   easily out-cascade, so darken the color directly at higher specificity. Uses
+   theme tokens, so it holds across all seven themes. */
+.v-application {
+  --v-medium-emphasis-opacity: 0.82;
+}
+.v-application .text-medium-emphasis {
+  color: color-mix(in srgb, rgb(var(--v-theme-on-surface)) 82%, transparent) !important;
+}
+
+/* Tooltips: a touch more breathing room than v4's tight 5px vertical default. */
+.v-tooltip > .v-overlay__content {
+  padding: 8px 14px;
+}
+
 /* Default card-text padding gets more air, but never overrides pa-* utilities
    (zero-specificity :where loses to any utility class by design). */
 :where(.v-card-text) {

--- a/web/src/assets/vuetify3-compat.css
+++ b/web/src/assets/vuetify3-compat.css
@@ -121,3 +121,26 @@
 .v-app-bar .v-toolbar__content {
   padding-inline: 20px;
 }
+
+/* ------------------------------------------------------------------ *
+ * 10. Field text size. Vuetify 4 renders the actual input/textarea text
+ *     (.v-field__input) at ~14px — and smaller under density="compact" —
+ *     which is hard to read while typing. Setting font-size on .v-field
+ *     alone does NOT reach the input, so pin it here (16px also avoids iOS
+ *     tap-to-zoom). Applies to every field type app-wide.
+ * ------------------------------------------------------------------ */
+.v-field .v-field__input {
+  font-size: 1rem;
+}
+
+/* ------------------------------------------------------------------ *
+ * 11. Button horizontal padding. In the v4 build, text/elevated buttons
+ *     render with 0 inline padding — labels sit flush to the edges, saved
+ *     only by min-width. Restore Vuetify's per-size padding; icon buttons
+ *     stay square (excluded).
+ * ------------------------------------------------------------------ */
+.v-btn--size-x-small:not(.v-btn--icon) { padding-inline: 8px; }
+.v-btn--size-small:not(.v-btn--icon)   { padding-inline: 12px; }
+.v-btn--size-default:not(.v-btn--icon) { padding-inline: 16px; }
+.v-btn--size-large:not(.v-btn--icon)   { padding-inline: 20px; }
+.v-btn--size-x-large:not(.v-btn--icon) { padding-inline: 24px; }

--- a/web/src/views/WODsView.vue
+++ b/web/src/views/WODsView.vue
@@ -99,11 +99,11 @@
 
             <!-- WOD Metadata Chips -->
             <div class="ml-7 d-flex flex-wrap gap-1">
-              <v-chip v-if="wod.score_type" size="x-small" color="#e0e0e0">
+              <v-chip v-if="wod.score_type" size="x-small" variant="tonal">
                 <v-icon start size="x-small">mdi-timer</v-icon>
                 {{ formatScoreType(wod.score_type) }}
               </v-chip>
-              <v-chip v-if="wod.source" size="x-small" color="#e0e0e0">
+              <v-chip v-if="wod.source" size="x-small" variant="tonal">
                 <v-icon start size="x-small">mdi-tag</v-icon>
                 {{ wod.source }}
               </v-chip>
@@ -261,11 +261,11 @@
 
           <!-- Score Type and Source -->
           <div v-if="selectedWOD.score_type || selectedWOD.source" class="mb-3">
-            <v-chip v-if="selectedWOD.score_type" size="small" color="#e0e0e0" class="mr-2">
+            <v-chip v-if="selectedWOD.score_type" size="small" variant="tonal" class="mr-2">
               <v-icon start size="x-small">mdi-timer</v-icon>
               {{ formatScoreType(selectedWOD.score_type) }}
             </v-chip>
-            <v-chip v-if="selectedWOD.source" size="small" color="#e0e0e0">
+            <v-chip v-if="selectedWOD.source" size="small" variant="tonal">
               <v-icon start size="x-small">mdi-tag</v-icon>
               {{ selectedWOD.source }}
             </v-chip>

--- a/web/src/views/WorkoutTimelineView.vue
+++ b/web/src/views/WorkoutTimelineView.vue
@@ -103,7 +103,7 @@
                     <v-chip
                       v-if="workout.movements.length > 3"
                       size="small"
-                      color="#e0e0e0"
+                      variant="tonal"
                       text-color="medium-emphasis"
                     >
                       +{{ workout.movements.length - 3 }} more

--- a/web/src/views/WorkoutsView.vue
+++ b/web/src/views/WorkoutsView.vue
@@ -156,7 +156,7 @@
 
             <!-- Display movements count -->
             <div v-if="template.movements && template.movements.length > 0" class="ml-7 mt-2">
-              <v-chip size="small" color="#e0e0e0" class="mr-1">
+              <v-chip size="small" variant="tonal" class="mr-1">
                 <v-icon start size="x-small">mdi-weight-lifter</v-icon>
                 {{ template.movements.length }} movement{{ template.movements.length > 1 ? 's' : '' }}
               </v-chip>
@@ -164,7 +164,7 @@
 
             <!-- Display WODs count -->
             <div v-if="template.wods && template.wods.length > 0" class="ml-7 mt-1">
-              <v-chip size="small" color="#e0e0e0" class="mr-1">
+              <v-chip size="small" variant="tonal" class="mr-1">
                 <v-icon start size="x-small">mdi-fire</v-icon>
                 {{ template.wods.length }} WOD{{ template.wods.length > 1 ? 's' : '' }}
               </v-chip>


### PR DESCRIPTION
Follow-up fixes on the v1.3.5 Vuetify 4 build, all surfaced while testing on beta. Global and theme-token based.

- **Entry-field text too small:** `.v-field__input` pinned to 16px (v4 rendered it ~14px, smaller under `density="compact"` — 342 usages across 54 files; a `.v-field` font-size never reaches the input). Also avoids iOS tap-zoom.
- **Low-emphasis text too light:** `text-medium-emphasis` 0.6 → 0.82 alpha.
- **Card count chips invisible:** `<v-chip color="#e0e0e0">` sets near-white *text* under v4 tonal; → `variant="tonal"` (readable) in WorkoutsView/WODsView/WorkoutTimelineView.
- **Text buttons flush to edges:** restored per-size inline padding; icon buttons excluded.
- **Cramped tooltips:** padding 5/16 → 8/14.

Verified on a local v4 build: field text 14→16px, caption alpha 0.6→0.82, chip text near-white→on-surface, button padding 0→16px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)