### PR TITLE
Notes field fix + amd64-only CI — v1.3.7

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -99,7 +99,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - name: Generate build summary
         run: |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to ActaLog will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.7] - 2026-07-19 — Notes field fix + faster CI
+
+### Fixed
+- **Log Workout "Notes" fields: the field label overlapped the placeholder hint.**
+  The per-movement and per-WOD Notes textareas set both a floating `label="Notes"`
+  and a `placeholder`; in the compact solo textarea (Vuetify 4) the floated label
+  rendered on top of the placeholder text. Dropped the redundant label; the field
+  now shows a single "Notes — how did this feel?" placeholder.
+
+### CI
+- Build the release image for **linux/amd64 only** (dropped the arm64 QEMU leg,
+  which pushed builds to ~20min); no arm64 deploy target exists.
+
 ## [1.3.6] - 2026-07-19 — Vuetify 4 UI polish (readability & spacing)
 
 Follow-up readability/spacing fixes on the v1.3.5 Vuetify 4 build, all found while

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,11 +9,11 @@ const (
 	// Minor version number
 	Minor = 3
 	// Patch version number
-	Patch = 6
+	Patch = 7
 	// PreRelease identifier (e.g., "alpha", "beta", "rc1")
 	PreRelease = ""
 	// Build number - increment this with each code change
-	Build = 60
+	Build = 61
 )
 
 // Version returns the full semantic version string

--- a/web/src/views/LogWorkoutView.vue
+++ b/web/src/views/LogWorkoutView.vue
@@ -214,13 +214,11 @@
             </v-row>
             <v-textarea
               v-model="movement.notes"
-              label="Notes"
-
               density="compact"
               hide-details
               rows="2"
               class="mt-2"
-              placeholder="How did this feel?"
+              placeholder="Notes — how did this feel?"
             />
             <v-select
               v-model="movement.rpe"
@@ -361,13 +359,11 @@
 
             <v-textarea
               v-model="wod.notes"
-              label="Notes"
-
               density="compact"
               hide-details
               rows="2"
               class="mt-2"
-              placeholder="How did this feel?"
+              placeholder="Notes — how did this feel?"
             />
             <v-select
               v-model="wod.rpe"


### PR DESCRIPTION
Two changes, bundled as v1.3.7:

**Fix: Log Workout Notes fields** — the per-movement/per-WOD Notes textareas had both a floating `label="Notes"` and a `placeholder`; in the compact solo textarea (Vuetify 4) the label rendered on top of the placeholder (see beta testing). Dropped the redundant label; the field now shows a single "Notes — how did this feel?" placeholder. 43/43 LogWorkoutView tests pass locally.

**CI:** build the release image amd64-only (drop the arm64 QEMU leg that pushed builds to ~20min; no arm64 target exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)