### PR TITLE
fix: make workout date test timezone-safe

### DIFF
--- a/web/src/views/LogWorkoutView.test.js
+++ b/web/src/views/LogWorkoutView.test.js
@@ -38,6 +38,7 @@ vi.mock('@/utils/rpe', () => ({
 }))
 
 import axios from '@/utils/axios'
+import { getTodayInTimezone } from '@/utils/timezone'
 
 describe('LogWorkoutView', () => {
   let wrapper
@@ -205,9 +206,9 @@ describe('LogWorkoutView', () => {
       await flushPromises()
 
       const vm = wrapper.vm
-      // Use local date format to match component's getTodayDate()
-      const now = new Date()
-      const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+      // The component uses the settings store's default timezone when no
+      // persisted user settings have been loaded yet.
+      const today = getTodayInTimezone('America/New_York')
 
       expect(vm.workoutDate).toBe(today)
     })


### PR DESCRIPTION
## Summary

Fixes a timezone-dependent frontend test that fails around midnight UTC.

The component uses the settings store timezone (default: America/New_York), but the test constructed its expected date in the runner's local timezone. The test now uses the same getTodayInTimezone helper and default timezone as the component.

## RunReplay investigation

- failed job: https://github.com/johnzastrow/actalog/actions/runs/29711317401/job/88255549303
- baseline job: https://github.com/johnzastrow/actalog/actions/runs/29699700709/job/88226532165
- workflow and Action revisions: unchanged in the comparison
- changed repository input: web/src/views/LogWorkoutView.vue`n- failing step: Run frontend tests`n- failure: expected 2026-07-19, received 2026-07-18 around a timezone boundary

## Validation


pm run test:run -- src/views/LogWorkoutView.test.js`n
Result: 43 passing tests.