### PR TITLE
fix(docker): health probe could never pass and killed the healthy app

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,8 +102,11 @@ USER actalog
 EXPOSE 8080
 
 # Health check
+# Probe 127.0.0.1 rather than "localhost": where localhost resolves to ::1 first,
+# wget targets [::1] while the server binds IPv4 only, so the check never passes.
+# Shell form (not exec form) so ${SERVER_PORT} is expanded at runtime.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider "http://127.0.0.1:${SERVER_PORT:-8080}/health" || exit 1
 
 # Set default environment variables
 ENV DB_DRIVER=sqlite3 \

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -23,8 +23,13 @@ for i in $(seq 1 30); do
         exit 1
     fi
 
-    # Check if the health endpoint responds
-    if wget -q -O- http://localhost:8080/health > /dev/null 2>&1; then
+    # Check if the health endpoint responds.
+    # Use 127.0.0.1, not "localhost": on hosts where localhost resolves to ::1
+    # first, wget connects to [::1] while the server binds IPv4 only (SERVER_HOST
+    # defaults to 0.0.0.0 and is commonly set to 127.0.0.1), so the probe can
+    # never succeed. Honour SERVER_PORT so non-default ports (e.g. a beta
+    # instance on 8081) probe themselves rather than another instance on 8080.
+    if wget -q -O- "http://127.0.0.1:${SERVER_PORT:-8080}/health" > /dev/null 2>&1; then
         echo "ActaLog is ready!"
         READY=1
         break
@@ -33,14 +38,23 @@ for i in $(seq 1 30); do
 done
 
 if [ $READY -eq 0 ]; then
-    echo "ERROR: ActaLog failed to become healthy within 30 seconds"
-    echo "The process is running but not responding. Check logs for details."
-    kill $APP_PID 2>/dev/null || true
-    exit 1
+    # Do NOT kill the app here. This readiness poll exists only to gate the
+    # optional seed import below; it is not a liveness supervisor. A probe that
+    # kills a healthy process turns any probe defect into a permanent crash-loop
+    # (with restart: unless-stopped this produced 25,946 restarts and a 9-day
+    # prod outage). The process-died check inside the loop above still exits 1
+    # for a genuinely dead app, and Docker's HEALTHCHECK reports health state.
+    echo "WARNING: ActaLog did not answer the readiness probe within 30 seconds"
+    echo "Continuing anyway - the process is running. Skipping seed import."
+    echo "Check Docker's HEALTHCHECK status and the logs above if the app is unreachable."
 fi
 
-# Run seed import script (only if ADMIN_EMAIL and ADMIN_PASSWORD are set)
-if [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
+# Run seed import script (only if the app answered the readiness probe and
+# ADMIN_EMAIL and ADMIN_PASSWORD are set) - seeding drives the HTTP API, so it
+# cannot work while the app is unreachable.
+if [ $READY -eq 0 ]; then
+    echo "Skipping seed import: app did not answer the readiness probe."
+elif [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
     echo "Admin credentials provided. Running seed import script..."
     /app/scripts/init-seeds.sh || echo "Warning: Seed import failed or was skipped"
 else

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to ActaLog will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.8] - 2026-07-29 — Fix container health probe that crash-looped prod
+
+### Fixed
+- **The container readiness probe could never succeed, and it killed the healthy
+  app when it failed — crash-looping both deployments for 9 days.**
+  `docker/scripts/entrypoint.sh` polled `http://localhost:8080/health`. Two defects:
+  - **`localhost` vs IPv4.** On hosts where `localhost` resolves to `::1` first,
+    wget connects to `[::1]` while the server binds IPv4 only (`SERVER_HOST`
+    defaults to `0.0.0.0` and is commonly set to `127.0.0.1`), so the probe was
+    refused every time. Verified against a live, working instance:
+    `localhost:8081` → `Connection refused`, `127.0.0.1:8081` → `{"status":"healthy"}`.
+  - **Hardcoded port 8080.** `SERVER_PORT` was ignored, so a beta instance on 8081
+    probed the *production* instance on 8080 instead of itself.
+
+  Both now use `http://127.0.0.1:${SERVER_PORT:-8080}/health`. The same two fixes
+  are applied to the Dockerfile `HEALTHCHECK` (kept in shell form so `${SERVER_PORT}`
+  expands at runtime).
+
+- **The readiness probe no longer kills the application.** On timeout the entrypoint
+  now logs a warning, skips the seed import (which drives the HTTP API and cannot
+  work while the app is unreachable), and hands off to `wait $APP_PID`. Previously
+  it ran `kill $APP_PID; exit 1`, which combined with `restart: unless-stopped` turned
+  any probe defect into a permanent crash-loop — 25,946 restarts on prod and 26,413
+  on beta, with zero successful readiness checks, starting at the 2026-07-20 deploy.
+  This poll only ever gated the optional seed import; it was never a liveness
+  supervisor. A genuinely dead process is still caught by the in-loop `kill -0`
+  check (exit 1), and Docker's `HEALTHCHECK` remains the health signal.
+
+### Operations
+- Deploy-time verification should probe from **inside** the container
+  (`docker exec <c> wget -q -O- http://127.0.0.1:$SERVER_PORT/health`), not with
+  `curl` from the host. Host-side `curl` resolves `localhost` to `127.0.0.1` and
+  reported healthy throughout, which is why this stayed hidden for 9 days.
+
 ## [1.3.7] - 2026-07-19 — Notes field fix + faster CI
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,11 +9,11 @@ const (
 	// Minor version number
 	Minor = 3
 	// Patch version number
-	Patch = 7
+	Patch = 8
 	// PreRelease identifier (e.g., "alpha", "beta", "rc1")
 	PreRelease = ""
 	// Build number - increment this with each code change
-	Build = 61
+	Build = 62
 )
 
 // Version returns the full semantic version string


### PR DESCRIPTION
## Summary

The container readiness probe in `docker/scripts/entrypoint.sh` could **never succeed**, and on failure it **killed the healthy application**. With `restart: unless-stopped` that became a permanent ~40s crash-loop.

This caused a production outage on `al.fluidgrid.site`: **25,946 failed probes and zero successes**, starting at the exact minute of the v1.3.7 deploy (2026-07-20 01:49). Beta logged 26,413. The site flapped for 9 days (up ~30s, killed, restart) before wedging completely when the container's containerd task vanished.

## Two defects made the probe unpassable

**1. `localhost` vs IPv4.** Where `localhost` resolves to `::1` first, wget targets `[::1]` while the server binds IPv4 only (`SERVER_HOST` defaults to `0.0.0.0` and is commonly set to `127.0.0.1`). Verified against a live, working instance:

```
localhost:8081  -> wget: can't connect to remote host: Connection refused
127.0.0.1:8081  -> {"status":"healthy","version":"1.3.7"}
```

**2. Hardcoded port 8080.** `SERVER_PORT` was ignored, so the beta instance on 8081 probed the *production* instance on 8080 instead of itself.

Both now use `http://127.0.0.1:${SERVER_PORT:-8080}/health`, in `entrypoint.sh` and in the Dockerfile `HEALTHCHECK` (kept in shell form so `${SERVER_PORT}` expands at runtime).

## The probe no longer kills the app

On timeout the entrypoint now warns, skips the seed import, and hands off to `wait $APP_PID`. This poll only ever gated the optional seed import (which requires `ADMIN_EMAIL`/`ADMIN_PASSWORD` and drives the HTTP API, so it cannot work while the app is unreachable) — it was never a liveness supervisor. A genuinely dead process is still caught by the in-loop `kill -0` check, and Docker's `HEALTHCHECK` remains the health signal.

## Testing

Behavioural tests against a stub server, not just diff review:

| Test | Result |
|---|---|
| Healthy app on non-default port 8099 | `ActaLog is ready!` — `SERVER_PORT` honoured |
| Unresponsive app | Warns, skips seeds, **app survives** to `wait` |
| **Control:** original script, healthy app on 8099 | Reproduces the bug — kills the healthy app |

`go build ./...` and `go test ./pkg/version/...` pass. `sh -n` clean (the one shellcheck SC2034 is pre-existing and on an untouched line).

## Deployment note

Production and beta are already restored via a compose-level workaround (`entrypoint: ["/app/actalog"]` plus a `127.0.0.1` healthcheck). Once a **v1.3.8** image ships, that `entrypoint:` override can be dropped from `~/actadocker/` and `~/actabetadocker/`.

Deploy-time health checks should probe from **inside** the container (`docker exec <c> wget -q -O- http://127.0.0.1:$SERVER_PORT/health`). Host-side `curl` resolves `localhost` to `127.0.0.1` and reported healthy throughout — which is why this stayed hidden for 9 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)